### PR TITLE
Fix README contributing link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ See [AWK in Java documentation](https://metricshub.org/Jawk/java.html)
 
 ## Contributing
 
-See [CONTRIBUDING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- fix link text for contributing instructions in README

## Testing
- `grep -n "CONTRIBUTING.md" README.md`
