### PR TITLE
Fix property name in AwkParameters Javadoc

### DIFF
--- a/src/main/java/org/metricshub/jawk/util/AwkParameters.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkParameters.java
@@ -64,7 +64,7 @@ import org.slf4j.Logger;
  *   and <code>printf</code>.
  * <li><i>Extension</i> -ext <br/>
  *   Enabled user-defined extensions. Works together with the
- *   -Djava.extensions property.
+ *   -Djawk.extensions property.
  *   It also disables blank rule as mapping to a print $0 statement.
  * <li><i>Extension</i> -ni <br/>
  *   Do NOT consume stdin or files from ARGC/V through input rules.


### PR DESCRIPTION
## Summary
- correct the system property mentioned for enabling extensions

## Testing
- `./mvnw -q -DskipTests install` *(fails: Non-resolvable parent POM)*