### PR TITLE
Fix handling of multiple intermediate files

### DIFF
--- a/src/main/java/org/metricshub/jawk/Awk.java
+++ b/src/main/java/org/metricshub/jawk/Awk.java
@@ -124,18 +124,18 @@ public class Awk {
 				LOG.trace("user extensions not enabled");
 			}
 
-			AwkTuples tuples = new AwkTuples();
-			// to be defined below
+                        AwkTuples tuples = new AwkTuples();
 
-			List<ScriptSource> notIntermediateScriptSources = new ArrayList<ScriptSource>(settings.getScriptSources().size());
-			for (ScriptSource scriptSource : settings.getScriptSources()) {
-				if (scriptSource.isIntermediate()) {
-					// read the intermediate file, bypassing frontend processing
-					tuples = (AwkTuples) readObjectFromInputStream(scriptSource.getInputStream()); // FIXME only the last intermediate file is used!
-				} else {
-					notIntermediateScriptSources.add(scriptSource);
-				}
-			}
+                        List<ScriptSource> notIntermediateScriptSources = new ArrayList<ScriptSource>(settings.getScriptSources().size());
+                        for (ScriptSource scriptSource : settings.getScriptSources()) {
+                                if (scriptSource.isIntermediate()) {
+                                        // read the intermediate file, bypassing frontend processing
+                                        AwkTuples partial = (AwkTuples) readObjectFromInputStream(scriptSource.getInputStream());
+                                        tuples.mergeFrom(partial);
+                                } else {
+                                        notIntermediateScriptSources.add(scriptSource);
+                                }
+                        }
 			if (!notIntermediateScriptSources.isEmpty()) {
 				AwkParser parser = new AwkParser(
 						settings.isAdditionalFunctions(),

--- a/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
@@ -3066,17 +3066,72 @@ public class AwkTuples implements Serializable {
 	 * properly.
 	 * </ul>
 	 */
-	public void postProcess() {
-		assert queue.isEmpty() || !queue.get(0).hasNext() : "postProcess() already executed";
-		// allocate nexts
-		for (int i = 0; i < queue.size() - 1; i++) {
-			queue.get(i).setNext(queue.get(i + 1));
-		}
-		// touch per element
-		for (Tuple tuple : queue) {
-			tuple.touch(queue);
-		}
-	}
+        public void postProcess() {
+                assert queue.isEmpty() || !queue.get(0).hasNext() : "postProcess() already executed";
+                // allocate nexts
+                for (int i = 0; i < queue.size() - 1; i++) {
+                        queue.get(i).setNext(queue.get(i + 1));
+                }
+                // touch per element
+                for (Tuple tuple : queue) {
+                        tuple.touch(queue);
+                }
+        }
+
+        /**
+         * Merge tuples and metadata from another {@link AwkTuples} instance into
+         * this one.  Address indexes of the appended tuples are shifted
+         * accordingly and queue links are fixed.
+         *
+         * @param other The {@link AwkTuples} instance whose content should be
+         *            appended to this instance.
+         */
+        public void mergeFrom(AwkTuples other) {
+                if (other == null || other.queue.isEmpty()) {
+                        return;
+                }
+
+                int offset = queue.size();
+
+                // fix next pointer of the last tuple in this queue
+                if (!queue.isEmpty()) {
+                        queue.get(queue.size() - 1).setNext(other.queue.get(0));
+                }
+
+                // shift indexes in address maps
+                for (Map.Entry<Integer, Address> e : other.address_indexes.entrySet()) {
+                        Address addr = e.getValue();
+                        if (addr.index() >= 0) {
+                                addr.assignIndex(addr.index() + offset);
+                        }
+                        address_indexes.put(e.getKey() + offset, addr);
+                }
+
+                // append tuples adjusting embedded addresses
+                for (Tuple t : other.queue) {
+                        if (t.address != null) {
+                                t.address.assignIndex(t.address.index() + offset);
+                        }
+                        if (t.hasFuncAddr != null) {
+                                Address a = t.hasFuncAddr.getFunctionAddress();
+                                if (a != null && a.index() >= 0) {
+                                        a.assignIndex(a.index() + offset);
+                                }
+                        }
+                        queue.add(t);
+                }
+
+                unresolved_addresses.addAll(other.unresolved_addresses);
+                address_label_counts.putAll(other.address_label_counts);
+                global_var_offset_map.putAll(other.global_var_offset_map);
+                global_var_aarray_map.putAll(other.global_var_aarray_map);
+                if (other.function_names != null) {
+                        if (function_names == null) {
+                                function_names = new HashSet<String>();
+                        }
+                        function_names.addAll(other.function_names);
+                }
+        }
 
 	/** Map of global variables offsets */
 	private Map<String, Integer> global_var_offset_map = new HashMap<String, Integer>();

--- a/src/test/java/org/metricshub/jawk/IntermediateFileTest.java
+++ b/src/test/java/org/metricshub/jawk/IntermediateFileTest.java
@@ -1,0 +1,61 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.metricshub.jawk.frontend.AwkParser;
+import org.metricshub.jawk.frontend.AwkSyntaxTree;
+import org.metricshub.jawk.intermediate.AwkTuples;
+import org.metricshub.jawk.util.AwkSettings;
+import org.metricshub.jawk.util.ScriptFileSource;
+import org.metricshub.jawk.util.ScriptSource;
+
+public class IntermediateFileTest {
+
+    private static File compileToAi(String script) throws Exception {
+        AwkParser parser = new AwkParser(false, false, Collections.emptyMap());
+        ScriptSource src = new ScriptSource("Body", new StringReader(script), false);
+        AwkSyntaxTree ast = parser.parse(Collections.singletonList(src));
+        ast.semanticAnalysis();
+        ast.semanticAnalysis();
+        AwkTuples tuples = new AwkTuples();
+        ast.populateTuples(tuples);
+        tuples.postProcess();
+        parser.populateGlobalVariableNameToOffsetMappings(tuples);
+        File f = File.createTempFile("jawk-test", ".ai");
+        f.deleteOnExit();
+        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(f))) {
+            oos.writeObject(tuples);
+        }
+        return f;
+    }
+
+    @Test
+    public void testMultipleIntermediateFiles() throws Exception {
+        File ai1 = compileToAi("BEGIN { print \"A\" }");
+        File ai2 = compileToAi("BEGIN { print \"B\" }");
+
+        AwkSettings settings = new AwkSettings();
+        settings.setDefaultRS("\n");
+        settings.setDefaultORS("\n");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        settings.setOutputStream(new PrintStream(baos));
+
+        settings.addScriptSource(new ScriptFileSource(ai1.getAbsolutePath()));
+        settings.addScriptSource(new ScriptFileSource(ai2.getAbsolutePath()));
+
+        Awk awk = new Awk();
+        awk.invoke(settings);
+
+        assertEquals("A\nB\n", baos.toString("UTF-8"));
+    }
+}


### PR DESCRIPTION
## Summary
- accumulate `.ai` files instead of overwriting when invoking Awk
- support merging AwkTuples objects
- add unit test ensuring multiple intermediate files work

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*