### PR TITLE
Fix argument terminator handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/util/AwkParameters.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkParameters.java
@@ -109,8 +109,8 @@ public class AwkParameters {
 	 * <p>
 	 * The command-line argument semantics are as follows:
 	 * <ul>
-	 * <li>First, "-" arguments are processed until first non-"-" argument
-	 *   is encountered, or the "-" itself is provided.
+         * <li>First, "-" arguments are processed until the first non-option argument
+         *   is encountered, or the "--" argument is provided.
 	 * <li>Next, a script is expected (unless the -f argument was provided).
 	 * <li>Then, subsequent parameters are passed into the script
 	 *   via the ARGC/ARGV variables.
@@ -135,10 +135,10 @@ public class AwkParameters {
 				if (args[argIdx].charAt(0) != '-') {
 					// no more -X arguments
 					break;
-				} else if (args[argIdx].equals("-")) {
-					// no more -X arguments
-					++argIdx;
-					break;
+                                } else if (args[argIdx].equals("--")) {
+                                        // no more -X arguments
+                                        ++argIdx;
+                                        break;
 				} else if (args[argIdx].equals("-v")) {
 					checkParameterHasArgument(args, argIdx);
 					++argIdx;

--- a/src/main/java/org/metricshub/jawk/util/AwkSettings.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkSettings.java
@@ -64,8 +64,9 @@ public class AwkSettings {
 	/**
 	 * Script sources meta info.
 	 * This will usually be either one String container,
-	 * made up of the script given on the command line directly,
-	 * with the first non-"-" parameter,
+         * made up of the script given on the command line directly,
+         * with the first non-option parameter,
+         * or after the "--" argument,
 	 * or one or multiple script file names (if provided with -f switches).
 	 */
 	private List<ScriptSource> scriptSources = new ArrayList<ScriptSource>();
@@ -278,8 +279,9 @@ public class AwkSettings {
 	 *
 	 * @return the script sources meta info.
 	 * This will usually be either one String container,
-	 * made up of the script given on the command line directly,
-	 * with the first non-"-" parameter,
+         * made up of the script given on the command line directly,
+         * with the first non-option parameter,
+         * or after the "--" argument,
 	 * or one or multiple script file names (if provided with -f switches).
 	 */
 	public List<ScriptSource> getScriptSources() {
@@ -364,8 +366,9 @@ public class AwkSettings {
 	/**
 	 * Script sources meta info.
 	 * This will usually be either one String container,
-	 * made up of the script given on the command line directly,
-	 * with the first non-"-" parameter,
+         * made up of the script given on the command line directly,
+         * with the first non-option parameter,
+         * or after the "--" argument,
 	 * or one or multiple script file names (if provided with -f switches).
 	 *
 	 * @param scriptSources the scriptSources to set

--- a/src/main/java/org/metricshub/jawk/util/ScriptSource.java
+++ b/src/main/java/org/metricshub/jawk/util/ScriptSource.java
@@ -29,7 +29,8 @@ import java.io.Reader;
 /**
  * Represents one AWK-script content source.
  * This is usually either a string,
- * given on the command line with the first non-"-" parameter,
+ * given on the command line with the first non-option parameter,
+ * or after the "--" argument,
  * or an "*.awk" (normal) or "*.ai" (intermediate) script,
  * given as a path with a "-f" command line switch.
  *

--- a/src/test/java/org/metricshub/jawk/OptionParsingTest.java
+++ b/src/test/java/org/metricshub/jawk/OptionParsingTest.java
@@ -1,0 +1,39 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+
+import org.junit.Test;
+import org.metricshub.jawk.util.AwkParameters;
+import org.metricshub.jawk.util.AwkSettings;
+
+public class OptionParsingTest {
+
+    @Test
+    public void doubleDashStopsOptionParsing() throws IOException {
+        String[] args = {"-v", "x=1", "--", "BEGIN { print ARGV[1] }", "-v", "y=2"};
+        AwkSettings settings = AwkParameters.parseCommandLineArguments(args);
+
+        assertEquals(1, settings.getVariables().get("x"));
+
+        Reader reader = settings.getScriptSources().get(0).getReader();
+        try (BufferedReader br = new BufferedReader(reader)) {
+            assertEquals("BEGIN { print ARGV[1] }", br.readLine());
+        }
+
+        assertEquals(2, settings.getNameValueOrFileNames().size());
+        assertEquals("-v", settings.getNameValueOrFileNames().get(0));
+        assertEquals("y=2", settings.getNameValueOrFileNames().get(1));
+    }
+
+    @Test
+    public void singleDashAfterScriptIsFileName() {
+        String[] args = {"BEGIN { }", "-"};
+        AwkSettings settings = AwkParameters.parseCommandLineArguments(args);
+        assertEquals(1, settings.getNameValueOrFileNames().size());
+        assertEquals("-", settings.getNameValueOrFileNames().get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- switch from single dash to POSIX `--` for stopping option parsing
- update related documentation comments
- add tests covering `--` and `-` argument behaviour

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*