### PR TITLE
Fix PMD warning in BlockManager

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/BlockManager.java
+++ b/src/main/java/org/metricshub/jawk/jrt/BlockManager.java
@@ -143,7 +143,7 @@ public class BlockManager {
 					BlockManager.this.notify();
 				}
                         } catch (InterruptedException ie) {
-                                Thread.currentThread().interrupt();
+                                currentThread().interrupt();
                         } catch (RuntimeException re) {
 				LOG.error("exitting", re);
 				System.exit(1);


### PR DESCRIPTION
## Summary
- address PMD UnnecessaryFullyQualifiedName in `BlockManager`

## Testing
- `mvn test --offline`
- `mvn -q site --offline`