### PR TITLE
Fix SUBSEP handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -1883,7 +1883,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 							//String s;
 							String convfmt = getCONVFMT().toString();
 							if (count == 1) {
-								//s = JRT.toAwkString(pop(), convfmt);
+								push(JRT.toAwkString(pop(), convfmt, locale));
 							} else {
 								StringBuilder sb = new StringBuilder();
 								sb.append(JRT.toAwkString(pop(), convfmt, locale));

--- a/src/test/java/org/metricshub/jawk/AwkTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTest.java
@@ -448,4 +448,14 @@ public class AwkTest {
 
 		assertEquals("gsub must replace '$0' with '$0'", "a _$0_ _$0_ d e\n", runAwk("{ gsub(/[b-c]/, \"_$0_\"); print $0; }", "a b c d e"));
 	}
+
+	@Test
+	public void testMultiDimensionalArrayWithSubsep() throws Exception {
+		assertEquals("42\n", runAwk("BEGIN { SUBSEP=\"@\"; a[1,2]=42; print a[1 SUBSEP 2]; }", null));
+	}
+
+	@Test
+	public void testSubsepChangeAfterIndexCreation() throws Exception {
+		assertEquals("42\n\n", runAwk("BEGIN { SUBSEP=\"@\"; idx = 1 SUBSEP 2; a[idx]=42; SUBSEP=\":\"; print a[idx]; print a[1,2]; }", null));
+	}
 }


### PR DESCRIPTION
## Summary
- handle SUBSEP when there is a single index in AVM
- add tests for SUBSEP and multidimensional array behaviour

## Testing
- `mvn --offline test`
- `mvn --offline -DskipTests site`
