### PR TITLE
Improve Jawk documentation

### DIFF
--- a/src/site/markdown/cli.md
+++ b/src/site/markdown/cli.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-* Download [jawk-${project.version}-standalone.jar](https://github.com/metricshub/Jawk/releases/download/v${project.version}/jawk-${project.version}-standalone.jar) from the [latest release](releases)
+* Download [jawk-${project.version}-standalone.jar](https://github.com/metricshub/Jawk/releases/download/v${project.version}/jawk-${project.version}-standalone.jar) from the [latest release](https://github.com/metricshub/Jawk/releases)
 * Make sure to have Java installed on your system ([download](https://adoptium.net/))
 * Execute `jawk-${project.version}-standalone.jar` just like the "traditional" AWK:
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -12,7 +12,7 @@ This project is forked from the excellent [Jawk project](https://jawk.sourceforg
 
 It's very simple:
 
-* Download [jawk-${project.version}-standalone.jar](https://github.com/metricshub/Jawk/releases/download/v${project.version}/jawk-${project.version}-standalone.jar) from the [latest release](releases)
+* Download [jawk-${project.version}-standalone.jar](https://github.com/metricshub/Jawk/releases/download/v${project.version}/jawk-${project.version}-standalone.jar) from the [latest release](https://github.com/metricshub/Jawk/releases)
 * Make sure to have Java installed on your system ([download](https://adoptium.net/))
 * Execute `jawk-${project.version}-standalone.jar` just like the "traditional" AWK
 


### PR DESCRIPTION
## Summary
- update links to the GitHub release page
- clarify how to depend on Jawk from Maven Central
- fix outdated code examples for using Jawk from Java
- document JSR 223 usage and known limitations

## Testing
- `mvn test --offline`
- `mvn site --offline`