### PR TITLE
Add JSR-223 ScriptEngine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,12 @@
 		</developer>
 	</developers>
 
-	<properties>
-		<!-- Java 8 -->
-		<maven.compiler.release>8</maven.compiler.release>
+        <properties>
+                <!-- Java 8 -->
+                <maven.compiler.source>8</maven.compiler.source>
+                <maven.compiler.target>8</maven.compiler.target>
 
-		<!-- Reproducible Build -->
+                <!-- Reproducible Build -->
 		<!-- See https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
 		<project.build.outputTimestamp>2025-04-03T12:56:26Z</project.build.outputTimestamp>
 	</properties>
@@ -113,7 +114,15 @@
 	</dependencies>
 
 	<build>
-		<plugins>
+                <plugins>
+
+                        <plugin>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <configuration>
+                                        <source>8</source>
+                                        <target>8</target>
+                                </configuration>
+                        </plugin>
 
 			<plugin>
 				<groupId>com.hubspot.maven.plugins</groupId>

--- a/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
+++ b/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
@@ -1,0 +1,110 @@
+package org.metricshub.jawk.jsr223;
+
+import java.io.BufferedReader;
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+import org.metricshub.jawk.Awk;
+import org.metricshub.jawk.ExitException;
+import org.metricshub.jawk.util.AwkSettings;
+import org.metricshub.jawk.util.ScriptSource;
+
+/** Simple JSR-223 script engine for Jawk. */
+public class JawkScriptEngine extends AbstractScriptEngine {
+
+	private final ScriptEngineFactory factory;
+
+	public JawkScriptEngine(ScriptEngineFactory factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public Object eval(String script, ScriptContext context) throws ScriptException {
+		try {
+			AwkSettings settings = new AwkSettings();
+			Object inObj = context.getAttribute("input");
+			if (inObj instanceof InputStream) {
+				settings.setInput((InputStream) inObj);
+			}
+			settings.setDefaultRS("\n");
+			settings.setDefaultORS("\n");
+			ByteArrayOutputStream result = new ByteArrayOutputStream();
+			settings.setOutputStream(new PrintStream(result));
+			settings.addScriptSource(new ScriptSource(ScriptSource.DESCRIPTION_COMMAND_LINE_SCRIPT, new StringReader(script), false));
+			Awk awk = new Awk();
+			awk.invoke(settings);
+			String out = result.toString(StandardCharsets.UTF_8.name());
+			Writer writer = context.getWriter();
+			if (writer != null) {
+				writer.write(out);
+				writer.flush();
+			}
+			return out;
+		} catch (ExitException e) {
+			if (e.getCode() != 0) {
+				throw new ScriptException(e);
+			}
+			return "";
+		} catch (Exception e) {
+			throw new ScriptException(e);
+		}
+	}
+
+	@Override
+	public Object eval(Reader reader, ScriptContext context) throws ScriptException {
+		try (BufferedReader br = new BufferedReader(reader)) {
+			StringBuilder sb = new StringBuilder();
+			char[] buf = new char[4096];
+			int n;
+			while ((n = br.read(buf)) != -1) {
+				sb.append(buf, 0, n);
+			}
+			return eval(sb.toString(), context);
+		} catch (IOException e) {
+			throw new ScriptException(e);
+		}
+	}
+
+	@Override
+	public Bindings createBindings() {
+		return new SimpleBindings();
+	}
+
+	@Override
+	public ScriptEngineFactory getFactory() {
+		return factory;
+	}
+}

--- a/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
+++ b/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
@@ -1,6 +1,5 @@
 package org.metricshub.jawk.jsr223;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
@@ -24,7 +23,6 @@ import java.io.ByteArrayInputStream;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.Reader;

--- a/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngineFactory.java
+++ b/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngineFactory.java
@@ -1,0 +1,116 @@
+package org.metricshub.jawk.jsr223;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+import java.util.Arrays;
+import java.util.List;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+
+/** ScriptEngineFactory for Jawk. */
+public class JawkScriptEngineFactory implements ScriptEngineFactory {
+
+	@Override
+	public String getEngineName() {
+		return "Jawk";
+	}
+
+	@Override
+	public String getEngineVersion() {
+		return "3.3.06-SNAPSHOT";
+	}
+
+	@Override
+	public List<String> getExtensions() {
+		return Arrays.asList("awk");
+	}
+
+	@Override
+	public List<String> getMimeTypes() {
+		return Arrays.asList("application/x-awk");
+	}
+
+	@Override
+	public List<String> getNames() {
+		return Arrays.asList("jawk", "Jawk");
+	}
+
+	@Override
+	public String getLanguageName() {
+		return "awk";
+	}
+
+	@Override
+	public String getLanguageVersion() {
+		return "1";
+	}
+
+	@Override
+	public Object getParameter(String key) {
+		if (ScriptEngine.NAME.equals(key) || ScriptEngine.ENGINE.equals(key)) {
+			return getEngineName();
+		}
+		if (ScriptEngine.ENGINE_VERSION.equals(key)) {
+			return getEngineVersion();
+		}
+		if (ScriptEngine.LANGUAGE.equals(key)) {
+			return getLanguageName();
+		}
+		if (ScriptEngine.LANGUAGE_VERSION.equals(key)) {
+			return getLanguageVersion();
+		}
+		return null;
+	}
+
+	@Override
+	public String getMethodCallSyntax(String obj, String m, String... args) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(obj).append(".").append(m).append("(");
+		for (int i = 0; i < args.length; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append(args[i]);
+		}
+		sb.append(")");
+		return sb.toString();
+	}
+
+	@Override
+	public String getOutputStatement(String toDisplay) {
+		return "print \"" + toDisplay.replace("\"", "\\\"") + "\"";
+	}
+
+	@Override
+	public String getProgram(String... statements) {
+		StringBuilder sb = new StringBuilder();
+		for (String s : statements) {
+			sb.append(s).append('\n');
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public ScriptEngine getScriptEngine() {
+		return new JawkScriptEngine(this);
+	}
+}

--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,1 @@
+org.metricshub.jawk.jsr223.JawkScriptEngineFactory

--- a/src/test/java/org/metricshub/jawk/ScriptEngineTest.java
+++ b/src/test/java/org/metricshub/jawk/ScriptEngineTest.java
@@ -1,0 +1,36 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import org.junit.Test;
+
+public class ScriptEngineTest {
+
+	@Test
+	public void testJawkScriptEngine() throws Exception {
+		ScriptEngineManager manager = new ScriptEngineManager();
+		ScriptEngine engine = manager.getEngineByName("jawk");
+		assertNotNull("Jawk ScriptEngine not found", engine);
+
+		String script = "{ print toupper($0) }";
+		String input = "hello world";
+
+		Bindings bindings = engine.createBindings();
+		bindings.put("input", new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+		StringWriter result = new StringWriter();
+		engine.getContext().setWriter(new PrintWriter(result));
+
+		engine.eval(script, bindings);
+
+		assertEquals("HELLO WORLD\n", result.toString());
+	}
+}


### PR DESCRIPTION
## Summary
- implement JSR-223 ScriptEngine and factory
- register the ScriptEngine as a service
- add unit test for ScriptEngine example
- configure compiler for Java 8

## Testing
- `mvn --offline test`
- `mvn --offline site`