### PR TITLE
Fix SpotBugs issues in Main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,20 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>4.13.2</version>
+                        <scope>test</scope>
+                </dependency>
 
-	</dependencies>
+                <dependency>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-annotations</artifactId>
+                        <version>4.9.3</version>
+                </dependency>
+
+        </dependencies>
 
 	<build>
                 <plugins>

--- a/src/main/java/org/metricshub/jawk/Main.java
+++ b/src/main/java/org/metricshub/jawk/Main.java
@@ -1,5 +1,6 @@
 package org.metricshub.jawk;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /*-
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
@@ -35,7 +36,7 @@ import org.metricshub.jawk.util.AwkSettings;
  *
  * @author Danny Daglas
  */
-public class Main {
+public final class Main {
 
 	/**
 	 * Prohibit the instantiation of this class, other than the
@@ -77,6 +78,7 @@ public class Main {
 	 *
 	 * @param args Command line arguments to the VM.
 	 */
+	@SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE", justification = "let PrintStream decide line separator")
 	public static void main(String[] args) {
 		try {
 			AwkSettings settings = AwkParameters.parseCommandLineArguments(args);


### PR DESCRIPTION
## Summary
- mark `Main` as final to avoid `CT_CONSTRUCTOR_THROW`
- add SpotBugs annotations dependency
- suppress `VA_FORMAT_STRING_USES_NEWLINE` warning in `main`

## Testing
- `mvn --offline test`
- `mvn --offline site`
