### PR TITLE
Fix EI_EXPOSE_REP2 warning

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/DataPump.java
+++ b/src/main/java/org/metricshub/jawk/jrt/DataPump.java
@@ -54,7 +54,7 @@ public class DataPump implements Runnable {
 	 */
 	public DataPump(InputStream in, PrintStream out) {
 		this.is = in;
-		this.os = out;
+		this.os = new PrintStream(out);
 		//setDaemon(true);
 	}
 


### PR DESCRIPTION
## Summary
- wrap PrintStream passed to DataPump constructor

## Testing
- `mvn test -DskipTests=false`
- `mvn site`