### PR TITLE
Fix BlockManager wait loop and error handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/BlockManager.java
+++ b/src/main/java/org/metricshub/jawk/jrt/BlockManager.java
@@ -89,6 +89,7 @@ public class BlockManager {
 
 		List<Thread> threadList = new LinkedList<Thread>();
 		synchronized (this) {
+			notifier = null;
 			for (BlockObject blockobj : bos) {
 				// spawn a thread
 				Thread t = new BlockThread(blockobj);
@@ -97,10 +98,12 @@ public class BlockManager {
 			}
 
 			// now, wait for notification from one of the BlockThreads
-			try {
-				this.wait();
-			} catch (InterruptedException ie) {
-				Thread.currentThread().interrupt();
+			while (notifier == null) {
+				try {
+					this.wait();
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+				}
 			}
 		}
 
@@ -145,7 +148,7 @@ public class BlockManager {
 				currentThread().interrupt();
 			} catch (RuntimeException re) {
 				LOG.error("exitting", re);
-				System.exit(1);
+				throw re;
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- surround `wait()` in `block()` with a loop to handle spurious wakeups
- reset notifier before starting threads
- in `BlockThread.run()`, rethrow runtime exceptions instead of calling `System.exit()`

## Testing
- `mvn --offline test`
- `mvn --offline -q site`