### PR TITLE
Fix DM_DEFAULT_ENCODING warnings

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -25,6 +25,7 @@ package org.metricshub.jawk.backend;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -328,8 +329,13 @@ public class AVM implements AwkInterpreter, VariableManager {
 					PrintStream ps = jrt.getOutputFiles().get(key);
 					if (ps == null) {
 						try {
-							jrt.getOutputFiles().put(key, ps = new PrintStream(new FileOutputStream(key, append), true)); // true =
-																																																						// autoflush
+							jrt
+									.getOutputFiles()
+									.put(
+											key,
+											ps = new PrintStream(new FileOutputStream(key, append), true, StandardCharsets.UTF_8.name())); // true
+							// =
+							// autoflush
 						} catch (IOException ioe) {
 							throw new AwkRuntimeException(position.lineNumber(), "Cannot open " + key + " for writing: " + ioe);
 						}
@@ -374,8 +380,13 @@ public class AVM implements AwkInterpreter, VariableManager {
 					PrintStream ps = jrt.getOutputFiles().get(key);
 					if (ps == null) {
 						try {
-							jrt.getOutputFiles().put(key, ps = new PrintStream(new FileOutputStream(key, append), true)); // true =
-																																																						// autoflush
+							jrt
+									.getOutputFiles()
+									.put(
+											key,
+											ps = new PrintStream(new FileOutputStream(key, append), true, StandardCharsets.UTF_8.name())); // true
+							// =
+							// autoflush
 						} catch (IOException ioe) {
 							throw new AwkRuntimeException(position.lineNumber(), "Cannot open " + key + " for writing: " + ioe);
 						}
@@ -1608,7 +1619,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 					// stack[0] = offset
 					subsep_offset = position.intArg(0);
 					assert subsep_offset != NULL_OFFSET;
-					assign(subsep_offset, new String(new byte[] { 28 }), true, position);
+					assign(subsep_offset, String.valueOf((char) 28), true, position);
 					pop(); // clean up the stack after the assignment
 					position.next();
 					break;

--- a/src/main/java/org/metricshub/jawk/jrt/DataPump.java
+++ b/src/main/java/org/metricshub/jawk/jrt/DataPump.java
@@ -25,6 +25,7 @@ package org.metricshub.jawk.jrt;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import org.metricshub.jawk.util.AwkLogger;
 import org.slf4j.Logger;
 
@@ -54,7 +55,11 @@ public class DataPump implements Runnable {
 	 */
 	public DataPump(InputStream in, PrintStream out) {
 		this.is = in;
-		this.os = new PrintStream(out);
+		try {
+			this.os = new PrintStream(out, false, StandardCharsets.UTF_8.name());
+		} catch (java.io.UnsupportedEncodingException e) {
+			throw new IllegalStateException(e);
+		}
 		// setDaemon(true);
 	}
 

--- a/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
+++ b/src/main/java/org/metricshub/jawk/jsr223/JawkScriptEngine.java
@@ -62,7 +62,11 @@ public class JawkScriptEngine extends AbstractScriptEngine {
 			settings.setDefaultRS("\n");
 			settings.setDefaultORS("\n");
 			ByteArrayOutputStream result = new ByteArrayOutputStream();
-			settings.setOutputStream(new PrintStream(result));
+			try {
+				settings.setOutputStream(new PrintStream(result, false, StandardCharsets.UTF_8.name()));
+			} catch (java.io.UnsupportedEncodingException e) {
+				throw new IllegalStateException(e);
+			}
 			settings.addScriptSource(new ScriptSource(ScriptSource.DESCRIPTION_COMMAND_LINE_SCRIPT, scriptReader, false));
 			Awk awk = new Awk();
 			awk.invoke(settings);


### PR DESCRIPTION
## Summary
- specify UTF-8 when constructing PrintStream or readers
- avoid default encoding when building SUBSEP string
- handle UnsupportedEncodingException where required

## Testing
- `mvn test --offline`
- `mvn site --offline -DskipTests`
