### PR TITLE
Improve docs for new Awk helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ See [Jawk CLI documentation](https://metricshub.org/Jawk/cli.html)
 
 ## Run AWK inside Java
 
-See [AWK in Java documentation](https://metricshub.org/Jawk/java.html)
+Execute a script in just one line using the convenience methods on `Awk`:
+
+```java
+String result = Awk.run("{ print toupper($0) }", "hello world");
+```
+
+See [AWK in Java documentation](https://metricshub.org/Jawk/java.html) for more details and advanced usage.
 
 ## Contributing
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -20,7 +20,14 @@ See [usage and examples of Jawk CLI](cli.html).
 
 ## Run AWK inside Java
 
-See [AWK in Java documentation](java.html).
+The `Awk` class provides several `run(...)` helpers to execute a script with one
+line of code:
+
+```java
+String output = Awk.run("{ print $1 }", "foo bar");
+```
+
+See [AWK in Java documentation](java.html) for advanced examples.
 
 ## Features
 

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -21,7 +21,20 @@ Jawk artifacts are published on Maven Central, so the dependency can be resolved
 
 ## Examples
 
-### Invoke AWK scripts files on input files
+### Quick execution with `Awk.run()`
+
+The `Awk` class offers static `run(...)` methods for the most common cases:
+
+```java
+String result = Awk.run("{ print toupper($0) }", "hello world");
+```
+
+### Advanced examples
+
+The examples below show how to configure `AwkSettings` directly to customize
+input sources, output handling or to register `JawkExtension`s.
+
+#### Invoke AWK script files on input files
 
 ```java
 /**
@@ -59,7 +72,7 @@ private String runAwk(File scriptFile, List<String> inputFileList) throws IOExce
 }
 ```
 
-### Execute AWK script (as String) on String input
+#### Execute AWK script (as String) on String input
 
 ```java
 /**


### PR DESCRIPTION
## Summary
- update README with simple `Awk.run` example
- mention convenience `run` helpers in the site index
- document quick and advanced examples of embedding Jawk in Java

## Testing
- `mvn --offline test`
- `mvn --offline site`
