### PR TITLE
Ignore EI_EXPOSE_REP warnings

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -68,6 +68,7 @@ import org.metricshub.jawk.util.MyStack;
 import org.metricshub.jawk.util.ScriptSource;
 import org.metricshub.printf4j.Printf4J;
 import org.slf4j.Logger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * The Jawk interpreter.
@@ -156,6 +157,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 	 *        interpreter.
 	 * @param extensions Map of the extensions to load
 	 */
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "constructor stores provided settings and extension map for later use")
 	public AVM(final AwkSettings parameters, final Map<String, JawkExtension> extensions) {
 		if (parameters == null) {
 			throw new IllegalArgumentException("AwkSettings can not be null");

--- a/src/main/java/org/metricshub/jawk/jrt/BlockObject.java
+++ b/src/main/java/org/metricshub/jawk/jrt/BlockObject.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * An item which blocks until something useful can be
@@ -93,6 +94,7 @@ public abstract class BlockObject {
 	 *
 	 * @param bo a {@link org.metricshub.jawk.jrt.BlockObject} object
 	 */
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Block chain uses direct references between block objects")
 	public void setNextBlockObject(BlockObject bo) {
 		this.nextBlockObject = bo;
 	}

--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
 import org.metricshub.jawk.intermediate.UninitializedObject;
 import org.metricshub.jawk.util.AwkLogger;
 import org.slf4j.Logger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * The Jawk runtime coordinator.
@@ -124,6 +125,7 @@ public class JRT {
 	 *
 	 * @param vm The VariableManager to use with this JRT.
 	 */
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "JRT must hold the provided VariableManager for later use")
 	public JRT(VariableManager vm) {
 		this.vm = vm;
 	}
@@ -570,6 +572,7 @@ public class JRT {
 	 *
 	 * @return a {@link org.metricshub.jawk.jrt.PartitioningReader} object
 	 */
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "PartitioningReader is shared across callers")
 	public PartitioningReader getPartitioningReader() {
 		return partitioningReader;
 	}
@@ -942,6 +945,7 @@ public class JRT {
 	 *
 	 * @return a {@link java.util.Map} object
 	 */
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Callers modify the map of output files directly")
 	public Map<String, PrintStream> getOutputFiles() {
 		return outputFiles;
 	}


### PR DESCRIPTION
## Summary
- suppress EI_EXPOSE_REP/EI_EXPOSE_REP2 warnings from SpotBugs

## Testing
- `mvn test`
- `mvn -DskipTests=false site`
