### PR TITLE
Add private constructor for AwkLogger

### DIFF
--- a/src/main/java/org/metricshub/jawk/util/AwkLogger.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkLogger.java
@@ -4,21 +4,19 @@ package org.metricshub.jawk.util;
  * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
  * Jawk
  * ჻჻჻჻჻჻
- * Copyright (C) 2006 - 2024 MetricsHub
+ * Copyright (C) 2006 - 2025 MetricsHub
  * ჻჻჻჻჻჻
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
@@ -32,6 +30,13 @@ import org.slf4j.LoggerFactory;
 public class AwkLogger {
 	static {
 		System.setProperty("slf4j.internal.verbosity", "WARN");
+	}
+
+	/**
+	 * Private constructor to prevent instantiation.
+	 */
+	private AwkLogger() {
+		// utility class
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- ensure `AwkLogger` cannot be instantiated
- update file header using Maven plugin

## Testing
- `mvn formatter:format -Dincludes="**/AwkLogger.java"`
- `mvn license:update-file-header -Dlicense.includes="**/AwkLogger.java"`
- `mvn test`
- `mvn verify site`

------
https://chatgpt.com/codex/tasks/task_b_683cb56dd2308321a770a97956d3a9e9