### PR TITLE
Fix parameter shadowing in AbstractExtension

### DIFF
--- a/src/main/java/org/metricshub/jawk/ext/AbstractExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/AbstractExtension.java
@@ -46,11 +46,11 @@ public abstract class AbstractExtension implements JawkExtension {
 	/** {@inheritDoc} */
 	@Override
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Extension needs direct access to runtime, VM and settings")
-	public void init(VariableManager vm, JRT jrt, final AwkSettings settings) {
-		this.vm = vm;
-		this.jrt = jrt;
-		this.settings = settings;
-	}
+       public void init(VariableManager vmParam, JRT runtime, final AwkSettings conf) {
+               this.vm = vmParam;
+               this.jrt = runtime;
+               this.settings = conf;
+       }
 
 	/**
 	 * Convert a Jawk variable to a Jawk string


### PR DESCRIPTION
## Notes
- `init` parameters no longer hide class fields.
- Source formatted and license headers updated via Maven.

## Summary
- rename `vm`, `jrt`, `settings` parameters in `AbstractExtension.init`
- assign renamed parameters to class fields

## Testing
- `mvn --offline test`
- `mvn --offline verify site`


------
https://chatgpt.com/codex/tasks/task_b_683cb561703483218b5bd05ca36f296c