### PR TITLE
Encapsulate AST structure fields

### DIFF
--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -2133,8 +2133,48 @@ public class AwkParser {
 
 		private final String sourceDescription = scriptSources.get(scriptSourcesCurrentIndex).getDescription();
 		private final int lineNo = reader.getLineNumber() + 1;
-		protected AST parent;
-		protected AST ast1, ast2, ast3, ast4;
+		private AST parent;
+		private AST ast1, ast2, ast3, ast4;
+
+		protected final AST getParent() {
+			return parent;
+		}
+
+		protected final void setParent(AST p) {
+			parent = p;
+		}
+
+		protected final AST getAst1() {
+			return ast1;
+		}
+
+		protected final void setAst1(AST a1) {
+			ast1 = a1;
+		}
+
+		protected final AST getAst2() {
+			return ast2;
+		}
+
+		protected final void setAst2(AST a2) {
+			ast2 = a2;
+		}
+
+		protected final AST getAst3() {
+			return ast3;
+		}
+
+		protected final void setAst3(AST a3) {
+			ast3 = a3;
+		}
+
+		protected final AST getAst4() {
+			return ast4;
+		}
+
+		protected final void setAst4(AST a4) {
+			ast4 = a4;
+		}
 
 		protected final AST searchFor(Class<?> cls) {
 			AST ptr = this;
@@ -2290,7 +2330,15 @@ public class AwkParser {
 			tuples.popSourceLineNumber(lineNo);
 		}
 
-		protected boolean is_begin = isBegin();
+		private boolean is_begin = isBegin();
+
+		protected final boolean isBeginFlag() {
+			return is_begin;
+		}
+
+		protected final void setBeginFlag(boolean flag) {
+			is_begin = flag;
+		}
 
 		private boolean isBegin() {
 			boolean result = is_begin;
@@ -2309,7 +2357,15 @@ public class AwkParser {
 			return result;
 		}
 
-		protected boolean is_end = isEnd();
+		private boolean is_end = isEnd();
+
+		protected final boolean isEndFlag() {
+			return is_end;
+		}
+
+		protected final void setEndFlag(boolean flag) {
+			is_end = flag;
+		}
 
 		private boolean isEnd() {
 			boolean result = is_end;
@@ -2322,27 +2378,35 @@ public class AwkParser {
 			if (!result && ast3 != null) {
 				result = ast3.isEnd();
 			}
-			if (!result && ast4 != null) {
-				result = ast4.isEnd();
+			if (!result && getAst4() != null) {
+				result = getAst4().isEnd();
 			}
 			return result;
 		}
 
-		protected boolean is_function = isFunction();
+		private boolean is_function = isFunction();
+
+		protected final boolean isFunctionFlag() {
+			return is_function;
+		}
+
+		protected final void setFunctionFlag(boolean flag) {
+			is_function = flag;
+		}
 
 		private boolean isFunction() {
 			boolean result = is_function;
-			if (!result && ast1 != null) {
-				result = ast1.isFunction();
+			if (!result && getAst1() != null) {
+				result = getAst1().isFunction();
 			}
-			if (!result && ast2 != null) {
-				result = ast2.isFunction();
+			if (!result && getAst2() != null) {
+				result = getAst2().isFunction();
 			}
-			if (!result && ast3 != null) {
-				result = ast3.isFunction();
+			if (!result && getAst3() != null) {
+				result = getAst3().isFunction();
 			}
-			if (!result && ast4 != null) {
-				result = ast4.isFunction();
+			if (!result && getAst4() != null) {
+				result = getAst4().isFunction();
 			}
 			return result;
 		}
@@ -2427,15 +2491,15 @@ public class AwkParser {
 		if (!isRule(ast)) {
 			return false;
 		}
-		if (ast.ast1 == null) {
+		if (ast.getAst1() == null) {
 			return false;
 		}
 
-		if (!containsASTType(ast.ast1, Extension_AST.class)) {
+		if (!containsASTType(ast.getAst1(), Extension_AST.class)) {
 			return false;
 		}
 
-		if (containsASTType(ast.ast1, new Class[] { FunctionCall_AST.class, DollarExpression_AST.class })) {
+		if (containsASTType(ast.getAst1(), new Class[] { FunctionCall_AST.class, DollarExpression_AST.class })) {
 			return false;
 		}
 
@@ -2456,10 +2520,10 @@ public class AwkParser {
 			}
 		}
 		// prettier-ignore
-		return containsASTType(ast.ast1, cls_array)
-				|| containsASTType(ast.ast2, cls_array)
-				|| containsASTType(ast.ast3, cls_array)
-				|| containsASTType(ast.ast4, cls_array);
+		return containsASTType(ast.getAst1(), cls_array)
+				|| containsASTType(ast.getAst2(), cls_array)
+				|| containsASTType(ast.getAst3(), cls_array)
+				|| containsASTType(ast.getAst4(), cls_array);
 	}
 
 	private Address next_address;
@@ -2491,13 +2555,13 @@ public class AwkParser {
 
 			ptr = this;
 			while (ptr != null) {
-				if (ptr.ast1 != null && ptr.ast1.isFunction()) {
-					assert ptr.ast1 != null;
-					int ast1_count = ptr.ast1.populateTuples(tuples);
+				if (ptr.getAst1() != null && ptr.getAst1().isFunction()) {
+					assert ptr.getAst1() != null;
+					int ast1_count = ptr.getAst1().populateTuples(tuples);
 					assert ast1_count == 0;
 				}
 
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 
 			// START OF MAIN BLOCK
@@ -2546,13 +2610,13 @@ public class AwkParser {
 
 			// grab all BEGINs
 			ptr = this;
-			// ptr.ast1 == blank rule condition (i.e.: { print })
+			// ptr.getAst1() == blank rule condition (i.e.: { print })
 			while (ptr != null) {
-				if (ptr.ast1 != null && ptr.ast1.isBegin()) {
-					ptr.ast1.populateTuples(tuples);
+				if (ptr.getAst1() != null && ptr.getAst1().isBegin()) {
+					ptr.getAst1().populateTuples(tuples);
 				}
 
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 
 			// Do we have rules? (apart from BEGIN)
@@ -2562,19 +2626,19 @@ public class AwkParser {
 			// Check for "normal" rules
 			ptr = this;
 			while (!req_input && (ptr != null)) {
-				if (isRule(ptr.ast1)) {
+				if (isRule(ptr.getAst1())) {
 					req_input = true;
 				}
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 
 			// Now check for "END" rules
 			ptr = this;
 			while (!req_input && (ptr != null)) {
-				if (ptr.ast1 != null && ptr.ast1.isEnd()) {
+				if (ptr.getAst1() != null && ptr.getAst1().isEnd()) {
 					req_input = true;
 				}
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 
 			if (req_input) {
@@ -2592,10 +2656,10 @@ public class AwkParser {
 				// grab all INPUT RULES
 				while (ptr != null) {
 					// the first one of these is an input rule
-					if (isRule(ptr.ast1)) {
-						ptr.ast1.populateTuples(tuples);
+					if (isRule(ptr.getAst1())) {
+						ptr.getAst1().populateTuples(tuples);
 					}
-					ptr = ptr.ast2;
+					ptr = ptr.getAst2();
 				}
 				tuples.address(next_address);
 
@@ -2616,10 +2680,10 @@ public class AwkParser {
 			// grab all ENDs
 			ptr = this;
 			while (ptr != null) {
-				if (ptr.ast1 != null && ptr.ast1.isEnd()) {
-					ptr.ast1.populateTuples(tuples);
+				if (ptr.getAst1() != null && ptr.getAst1().isEnd()) {
+					ptr.getAst1().populateTuples(tuples);
 				}
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 
 			// force a nop here to resolve any addresses that haven't been resolved yet
@@ -2641,19 +2705,19 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				// just indicate to execute the rule
 				tuples.push(1); // 1 == true
 			} else {
-				int result = ast1.populateTuples(tuples);
+				int result = getAst1().populateTuples(tuples);
 				assert result == 1;
 			}
 			// result of whether to execute or not is on the stack
 			Address bypass_rule = tuples.createAddress("bypass_rule");
 			tuples.ifFalse(bypass_rule);
 			// execute the opt_rule here!
-			if (ast2 == null) {
-				if (ast1 == null || (!ast1.isBegin() && !ast1.isEnd())) {
+			if (getAst2() == null) {
+				if (getAst1() == null || (!getAst1().isBegin() && !getAst1().isEnd())) {
 					// display $0
 					tuples.print(0);
 				}
@@ -2661,7 +2725,7 @@ public class AwkParser {
 				// (i.e., blank BEGIN/END rule)
 			} else {
 				// execute it, and leave nothing on the stack
-				int ast2_count = ast2.populateTuples(tuples);
+				int ast2_count = getAst2().populateTuples(tuples);
 				assert ast2_count == 0;
 			}
 			tuples.address(bypass_rule).nop();
@@ -2690,24 +2754,24 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
+			assert getAst1() != null;
 
 			Address elseblock = tuples.createAddress("elseblock");
 
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.ifFalse(elseblock);
-			if (ast2 != null) {
-				int ast2_result = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 0;
 			}
-			if (ast3 == null) {
+			if (getAst3() == null) {
 				tuples.address(elseblock);
 			} else {
 				Address end = tuples.createAddress("end");
 				tuples.gotoAddress(end);
 				tuples.address(elseblock);
-				int ast3_result = ast3.populateTuples(tuples);
+				int ast3_result = getAst3().populateTuples(tuples);
 				assert ast3_result == 0;
 				tuples.address(end);
 			}
@@ -2725,22 +2789,22 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			assert ast2 != null;
-			assert ast3 != null;
+			assert getAst1() != null;
+			assert getAst2() != null;
+			assert getAst3() != null;
 
 			Address elseexpr = tuples.createAddress("elseexpr");
 			Address end_tertiary = tuples.createAddress("end_tertiary");
 
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.ifFalse(elseexpr);
-			int ast2_result = ast2.populateTuples(tuples);
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 			tuples.gotoAddress(end_tertiary);
 
 			tuples.address(elseexpr);
-			int ast3_result = ast3.populateTuples(tuples);
+			int ast3_result = getAst3().populateTuples(tuples);
 			assert ast3_result == 1;
 
 			tuples.address(end_tertiary);
@@ -2785,13 +2849,13 @@ public class AwkParser {
 			continue_address = loop;
 
 			// condition
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.ifFalse(break_address);
 
-			if (ast2 != null) {
-				int ast2_result = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 0;
 			}
 
@@ -2836,8 +2900,8 @@ public class AwkParser {
 			Address loop = tuples.createAddress("loop");
 			tuples.address(loop);
 
-			if (ast1 != null) {
-				int ast1_result = ast1.populateTuples(tuples);
+			if (getAst1() != null) {
+				int ast1_result = getAst1().populateTuples(tuples);
 				assert ast1_result == 0;
 			}
 
@@ -2845,8 +2909,8 @@ public class AwkParser {
 			tuples.address(continue_address);
 
 			// condition
-			assert ast2 != null;
-			int ast2_result = ast2.populateTuples(tuples);
+			assert getAst2() != null;
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 			tuples.ifTrue(loop);
 
@@ -2888,8 +2952,8 @@ public class AwkParser {
 			continue_address = tuples.createAddress("continue_address");
 
 			// initial actions
-			if (ast1 != null) {
-				int ast1_result = ast1.populateTuples(tuples);
+			if (getAst1() != null) {
+				int ast1_result = getAst1().populateTuples(tuples);
 				for (int i = 0; i < ast1_result; i++) {
 					tuples.pop();
 				}
@@ -2898,17 +2962,17 @@ public class AwkParser {
 			Address loop = tuples.createAddress("loop");
 			tuples.address(loop);
 
-			if (ast2 != null) {
+			if (getAst2() != null) {
 				// condition
-				// assert(ast2 != null);
-				int ast2_result = ast2.populateTuples(tuples);
+				// assert(getAst2() != null);
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 1;
 				tuples.ifFalse(break_address);
 			}
 
-			if (ast4 != null) {
+			if (getAst4() != null) {
 				// post loop action
-				int ast4_result = ast4.populateTuples(tuples);
+				int ast4_result = getAst4().populateTuples(tuples);
 				assert ast4_result == 0;
 			}
 
@@ -2916,8 +2980,8 @@ public class AwkParser {
 			tuples.address(continue_address);
 
 			// post-loop action
-			if (ast3 != null) {
-				int ast3_result = ast3.populateTuples(tuples);
+			if (getAst3() != null) {
+				int ast3_result = getAst3().populateTuples(tuples);
 				for (int i = 0; i < ast3_result; i++) {
 					tuples.pop();
 				}
@@ -2957,9 +3021,9 @@ public class AwkParser {
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
 
-			assert ast2 != null;
+			assert getAst2() != null;
 
-			ID_AST array_id_ast = (ID_AST) ast2;
+			ID_AST array_id_ast = (ID_AST) getAst2();
 			if (array_id_ast.isScalar()) {
 				throw new SemanticException(array_id_ast + " is not an array");
 			}
@@ -2967,7 +3031,7 @@ public class AwkParser {
 
 			break_address = tuples.createAddress("break_address");
 
-			ast2.populateTuples(tuples);
+			getAst2().populateTuples(tuples);
 			// pops the array and pushes the keyset
 			tuples.keylist();
 
@@ -2993,12 +3057,12 @@ public class AwkParser {
 			tuples.dup();
 			tuples.getFirstAndRemoveFromList();
 			// assign it to the id
-			tuples.assign(((ID_AST) ast1).offset, ((ID_AST) ast1).is_global);
+			tuples.assign(((ID_AST) getAst1()).offset, ((ID_AST) getAst1()).is_global);
 			tuples.pop(); // remove the assignment result
 
-			if (ast3 != null) {
+			if (getAst3() != null) {
 				// execute the block
-				int ast3_result = ast3.populateTuples(tuples);
+				int ast3_result = getAst3().populateTuples(tuples);
 				assert ast3_result == 0;
 			}
 			// otherwise, there is no block to execute
@@ -3045,7 +3109,7 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			int expr_count = ast1.populateTuples(tuples);
+			int expr_count = getAst1().populateTuples(tuples);
 			if (expr_count == 1) {
 				tuples.pop();
 			} else if (expr_count != 0) {
@@ -3076,12 +3140,12 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast2 != null;
-			int ast2_count = ast2.populateTuples(tuples);
+			assert getAst2() != null;
+			int ast2_count = getAst2().populateTuples(tuples);
 			assert ast2_count == 1;
 			// here, stack contains one value
-			if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				if (id_ast.isArray()) {
 					throw new SemanticException("Cannot use " + id_ast + " as a scalar. It is an array.");
 				}
@@ -3108,14 +3172,14 @@ public class AwkParser {
 				if (id_ast.id.equals("RS")) {
 					tuples.applyRS();
 				}
-			} else if (ast1 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr = (ArrayReference_AST) ast1;
+			} else if (getAst1() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr = (ArrayReference_AST) getAst1();
 				// push the index
-				assert arr.ast2 != null;
-				int arr_ast2_result = arr.ast2.populateTuples(tuples);
+				assert arr.getAst2() != null;
+				int arr_ast2_result = arr.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				// push the array ref itself
-				ID_AST id_ast = (ID_AST) arr.ast1;
+				ID_AST id_ast = (ID_AST) arr.getAst1();
 				if (id_ast.isScalar()) {
 					throw new SemanticException("Cannot use " + id_ast + " as an array. It is a scalar.");
 				}
@@ -3137,10 +3201,10 @@ public class AwkParser {
 				} else {
 					throw new NotImplementedError("Unhandled op: " + op + " / " + text + " for arrays.");
 				}
-			} else if (ast1 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast1;
-				assert dollar_expr.ast1 != null;
-				int ast1_result = dollar_expr.ast1.populateTuples(tuples);
+			} else if (getAst1() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst1();
+				assert dollar_expr.getAst1() != null;
+				int ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				// stack contains eval of dollar arg
 
@@ -3162,7 +3226,7 @@ public class AwkParser {
 					throw new NotImplementedError("Unhandled op: " + op + " / " + text + " for dollar expressions.");
 				}
 			} else {
-				throw new SemanticException("Cannot perform an assignment on: " + ast1);
+				throw new SemanticException("Cannot perform an assignment on: " + getAst1());
 			}
 			popSourceLineNumber(tuples);
 			return 1;
@@ -3178,18 +3242,18 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			assert ast2 != null;
-			if (!(ast2 instanceof ID_AST)) {
+			assert getAst1() != null;
+			assert getAst2() != null;
+			if (!(getAst2() instanceof ID_AST)) {
 				throw new SemanticException("Expecting an array for rhs of IN. Got an expression.");
 			}
-			ID_AST arr_ast = (ID_AST) ast2;
+			ID_AST arr_ast = (ID_AST) getAst2();
 			if (arr_ast.isScalar()) {
 				throw new SemanticException("Expecting an array for rhs of IN. Got a scalar.");
 			}
 			arr_ast.setArray(true);
 
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 
 			int ast2_result = arr_ast.populateTuples(tuples);
@@ -3224,13 +3288,13 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			assert ast2 != null;
+			assert getAst1() != null;
+			assert getAst2() != null;
 
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 
-			int ast2_result = ast2.populateTuples(tuples);
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 
 			// 2 values on the stack
@@ -3288,7 +3352,7 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 			// exhibit short-circuit behavior
 			Address end = tuples.createAddress("end");
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.dup();
 			if (op == _OR_) {
@@ -3300,7 +3364,7 @@ public class AwkParser {
 				assert false : "Invalid op: " + op + " / " + text;
 			}
 			tuples.pop();
-			int ast2_result = ast2.populateTuples(tuples);
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 
 			tuples.address(end);
@@ -3334,9 +3398,9 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
-			int ast2_result = ast2.populateTuples(tuples);
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 			if (op == _PLUS_) {
 				tuples.add();
@@ -3367,11 +3431,11 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int lhs_count = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int lhs_count = getAst1().populateTuples(tuples);
 			assert lhs_count == 1;
-			assert ast2 != null;
-			int rhs_count = ast2.populateTuples(tuples);
+			assert getAst2() != null;
+			int rhs_count = getAst2().populateTuples(tuples);
 			assert rhs_count == 1;
 			tuples.concat();
 			popSourceLineNumber(tuples);
@@ -3388,8 +3452,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.negate();
 			popSourceLineNumber(tuples);
@@ -3406,8 +3470,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.unaryPlus();
 			popSourceLineNumber(tuples);
@@ -3424,8 +3488,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.not();
 			popSourceLineNumber(tuples);
@@ -3442,8 +3506,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.getInputField();
 			popSourceLineNumber(tuples);
@@ -3463,11 +3527,11 @@ public class AwkParser {
 			AST ptr = this;
 			int cnt = 0;
 			while (ptr != null) {
-				assert ptr.ast1 != null;
-				int ptr_ast1_result = ptr.ast1.populateTuples(tuples);
+				assert ptr.getAst1() != null;
+				int ptr_ast1_result = ptr.getAst1().populateTuples(tuples);
 				assert ptr_ast1_result == 1;
 				++cnt;
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 			assert cnt >= 1;
 			if (cnt > 1) {
@@ -3498,11 +3562,11 @@ public class AwkParser {
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
 			// typical recursive processing of a list
-			assert ast1 != null;
-			int ast1_count = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_count = getAst1().populateTuples(tuples);
 			assert ast1_count == 0;
-			if (ast2 != null) {
-				int ast2_count = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_count = getAst2().populateTuples(tuples);
 				assert ast2_count == 0;
 			}
 			popSourceLineNumber(tuples);
@@ -3511,7 +3575,7 @@ public class AwkParser {
 
 		@Override
 		public String toString() {
-			return super.toString() + " <" + ast1 + ">";
+			return super.toString() + " <" + getAst1() + ">";
 		}
 	}
 
@@ -3537,7 +3601,7 @@ public class AwkParser {
 		private FunctionDef_AST(String id, AST params, AST func_body) {
 			super(params, func_body);
 			this.id = id;
-			is_function = true;
+			setFunctionFlag(true);
 		}
 
 		public Address getAddress() {
@@ -3568,8 +3632,8 @@ public class AwkParser {
 
 			// execute the body
 			// (function body could be empty [no statements])
-			if (ast2 != null) {
-				int ast2_result = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 0 || ast2_result == 1;
 			}
 
@@ -3584,21 +3648,21 @@ public class AwkParser {
 		}
 
 		int paramCount() {
-			AST ptr = ast1;
+			AST ptr = getAst1();
 			int count = 0;
 			while (ptr != null) {
 				++count;
-				ptr = ptr.ast1;
+				ptr = ptr.getAst1();
 			}
 			return count;
 		}
 
 		void checkActualToFormalParameters(AST actual_param_list) {
 			AST a_ptr = actual_param_list;
-			FunctionDefParamList_AST f_ptr = (FunctionDefParamList_AST) ast1;
+			FunctionDefParamList_AST f_ptr = (FunctionDefParamList_AST) getAst1();
 			while (a_ptr != null) {
 				// actual parameter
-				AST aparam = a_ptr.ast1;
+				AST aparam = a_ptr.getAst1();
 				// formal function parameter
 				AST fparam = symbol_table.getFunctionParameterIDAST(id, f_ptr.id);
 
@@ -3624,8 +3688,8 @@ public class AwkParser {
 					}
 				}
 				// next
-				a_ptr = a_ptr.ast2;
-				f_ptr = (FunctionDefParamList_AST) f_ptr.ast1;
+				a_ptr = a_ptr.getAst2();
+				f_ptr = (FunctionDefParamList_AST) f_ptr.getAst1();
 			}
 		}
 	}
@@ -3667,7 +3731,7 @@ public class AwkParser {
 				throw new SemanticException("function " + function_proxy + " not defined");
 			}
 			int actual_param_count;
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				actual_param_count = 0;
 			} else {
 				actual_param_count = actualParamCount();
@@ -3683,8 +3747,8 @@ public class AwkParser {
 								+ " parameter(s), not "
 								+ actual_param_count);
 			}
-			if (ast1 != null) {
-				function_proxy.checkActualToFormalParameters(ast1);
+			if (getAst1() != null) {
+				function_proxy.checkActualToFormalParameters(getAst1());
 			}
 		}
 
@@ -3696,10 +3760,10 @@ public class AwkParser {
 			}
 			tuples.scriptThis();
 			int actual_param_count;
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				actual_param_count = 0;
 			} else {
-				actual_param_count = ast1.populateTuples(tuples);
+				actual_param_count = getAst1().populateTuples(tuples);
 			}
 			int formal_param_count = function_proxy.getFunctionParamCount();
 			if (formal_param_count < actual_param_count) {
@@ -3713,7 +3777,7 @@ public class AwkParser {
 								+ actual_param_count);
 			}
 
-			function_proxy.checkActualToFormalParameters(ast1);
+			function_proxy.checkActualToFormalParameters(getAst1());
 			tuples.callFunction(function_proxy, function_proxy.getFunctionName(), formal_param_count, actual_param_count);
 			popSourceLineNumber(tuples);
 			return 1;
@@ -3721,11 +3785,11 @@ public class AwkParser {
 
 		private int actualParamCount() {
 			int cnt = 0;
-			AST ptr = ast1;
+			AST ptr = getAst1();
 			while (ptr != null) {
-				assert ptr.ast1 != null;
+				assert ptr.getAst1() != null;
 				++cnt;
-				ptr = ptr.ast2;
+				ptr = ptr.getAst2();
 			}
 			return cnt;
 		}
@@ -3747,10 +3811,10 @@ public class AwkParser {
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
 			if (fIdx == BUILTIN_FUNC_NAMES.get("sprintf")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("sprintf requires at least 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result == 0) {
 					throw new SemanticException("sprintf requires at minimum 1 argument");
 				}
@@ -3758,10 +3822,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("close")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("close requires 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("close requires only 1 argument");
 				}
@@ -3769,10 +3833,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("length")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					tuples.length(0);
 				} else {
-					int ast1_result = ast1.populateTuples(tuples);
+					int ast1_result = getAst1().populateTuples(tuples);
 					if (ast1_result != 1) {
 						throw new SemanticException("length requires at least one argument");
 					}
@@ -3781,10 +3845,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("srand")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					tuples.srand(0);
 				} else {
-					int ast1_result = ast1.populateTuples(tuples);
+					int ast1_result = getAst1().populateTuples(tuples);
 					if (ast1_result != 1) {
 						throw new SemanticException("srand takes either 0 or one argument, not " + ast1_result);
 					}
@@ -3793,14 +3857,14 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("rand")) {
-				if (ast1 != null) {
+				if (getAst1() != null) {
 					throw new SemanticException("rand does not take arguments");
 				}
 				tuples.rand();
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("sqrt")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("sqrt requires only 1 argument");
 				}
@@ -3808,7 +3872,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("int")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("int requires only 1 argument");
 				}
@@ -3816,7 +3880,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("log")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("int requires only 1 argument");
 				}
@@ -3824,7 +3888,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("exp")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("exp requires only 1 argument");
 				}
@@ -3832,7 +3896,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("sin")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("sin requires only 1 argument");
 				}
@@ -3840,7 +3904,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("cos")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("cos requires only 1 argument");
 				}
@@ -3848,7 +3912,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("atan2")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 2) {
 					throw new SemanticException("atan2 requires 2 arguments");
 				}
@@ -3856,7 +3920,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("match")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 2) {
 					throw new SemanticException("match requires 2 arguments");
 				}
@@ -3864,7 +3928,7 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("index")) {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 2) {
 					throw new SemanticException("index requires 2 arguments");
 				}
@@ -3872,19 +3936,19 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("sub") || fIdx == BUILTIN_FUNC_NAMES.get("gsub")) {
-				if (ast1 == null || ast1.ast2 == null || ast1.ast2.ast1 == null) {
+				if (getAst1() == null || getAst1().getAst2() == null || getAst1().getAst2().getAst1() == null) {
 					throw new SemanticException("sub needs at least 2 arguments");
 				}
 				boolean isGsub = fIdx == BUILTIN_FUNC_NAMES.get("gsub");
 
-				int numargs = ast1.populateTuples(tuples);
+				int numargs = getAst1().populateTuples(tuples);
 
 				// stack contains arg1,arg2[,arg3] - in that pop() order
 
 				if (numargs == 2) {
 					tuples.subForDollar0(isGsub);
 				} else if (numargs == 3) {
-					AST ptr = ast1.ast2.ast2.ast1;
+					AST ptr = getAst1().getAst2().getAst2().getAst1();
 					if (ptr instanceof ID_AST) {
 						ID_AST id_ast = (ID_AST) ptr;
 						if (id_ast.isArray()) {
@@ -3895,9 +3959,9 @@ public class AwkParser {
 					} else if (ptr instanceof ArrayReference_AST) {
 						ArrayReference_AST arr_ast = (ArrayReference_AST) ptr;
 						// push the index
-						int ast2_result = arr_ast.ast2.populateTuples(tuples);
+						int ast2_result = arr_ast.getAst2().populateTuples(tuples);
 						assert ast2_result == 1;
-						ID_AST id_ast = (ID_AST) arr_ast.ast1;
+						ID_AST id_ast = (ID_AST) arr_ast.getAst1();
 						if (id_ast.isScalar()) {
 							throw new SemanticException("Cannot use " + id_ast + " as an array.");
 						}
@@ -3905,8 +3969,8 @@ public class AwkParser {
 					} else if (ptr instanceof DollarExpression_AST) {
 						// push the field ref
 						DollarExpression_AST dollar_expr = (DollarExpression_AST) ptr;
-						assert dollar_expr.ast1 != null;
-						int ast1_result = dollar_expr.ast1.populateTuples(tuples);
+						assert dollar_expr.getAst1() != null;
+						int ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 						assert ast1_result == 1;
 						tuples.subForDollarReference(isGsub);
 					} else {
@@ -3922,10 +3986,10 @@ public class AwkParser {
 				// the 2nd argument is pass by reference, which is ok (?)
 
 				// funccallparamlist.funccallparamlist.id_ast
-				if (ast1 == null || ast1.ast2 == null || ast1.ast2.ast1 == null) {
+				if (getAst1() == null || getAst1().getAst2() == null || getAst1().getAst2().getAst1() == null) {
 					throw new SemanticException("split needs at least 2 arguments");
 				}
-				AST ptr = ast1.ast2.ast1;
+				AST ptr = getAst1().getAst2().getAst1();
 				if (!(ptr instanceof ID_AST)) {
 					throw new SemanticException("split needs an array name as its 2nd argument");
 				}
@@ -3935,7 +3999,7 @@ public class AwkParser {
 				}
 				arr_ast.setArray(true);
 
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 2 && ast1_result != 3) {
 					throw new SemanticException("split requires 2 or 3 arguments, not " + ast1_result);
 				}
@@ -3943,10 +4007,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("substr")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("substr requires at least 2 arguments");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 2 && ast1_result != 3) {
 					throw new SemanticException("substr requires 2 or 3 arguments, not " + ast1_result);
 				}
@@ -3954,10 +4018,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("tolower")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("tolower requires 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("tolower requires only 1 argument");
 				}
@@ -3965,10 +4029,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("toupper")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("toupper requires 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("toupper requires only 1 argument");
 				}
@@ -3976,10 +4040,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("system")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("system requires 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("system requires only 1 argument");
 				}
@@ -3987,10 +4051,10 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1;
 			} else if (fIdx == BUILTIN_FUNC_NAMES.get("exec")) {
-				if (ast1 == null) {
+				if (getAst1() == null) {
 					throw new SemanticException("exec requires 1 argument");
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				if (ast1_result != 1) {
 					throw new SemanticException("exec requires only 1 argument");
 				}
@@ -4012,12 +4076,12 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
+			assert getAst1() != null;
 			int retval;
-			if (ast2 == null) {
-				retval = ast1.populateTuples(tuples);
+			if (getAst2() == null) {
+				retval = getAst1().populateTuples(tuples);
 			} else {
-				retval = ast1.populateTuples(tuples) + ast2.populateTuples(tuples);
+				retval = getAst1().populateTuples(tuples) + getAst2().populateTuples(tuples);
 			}
 			popSourceLineNumber(tuples);
 			return retval;
@@ -4048,7 +4112,7 @@ public class AwkParser {
 		@Override
 		public void semanticAnalysis() throws SemanticException {
 			// could do it recursively, but not necessary
-			// since all ast1's are FunctionDefParamList's
+			// since all getAst1()'s are FunctionDefParamList's
 			// and, thus, terminals (no need to do further
 			// semantic analysis)
 
@@ -4057,7 +4121,7 @@ public class AwkParser {
 				if (SPECIAL_VAR_NAMES.get(ptr.id) != null) {
 					throw new SemanticException("Special variable " + ptr.id + " cannot be used as a formal parameter");
 				}
-				ptr = (FunctionDefParamList_AST) ptr.ast1;
+				ptr = (FunctionDefParamList_AST) ptr.getAst1();
 			}
 		}
 	}
@@ -4129,19 +4193,19 @@ public class AwkParser {
 
 		@Override
 		public String toString() {
-			return super.toString() + " (" + ast1 + " [...])";
+			return super.toString() + " (" + getAst1() + " [...])";
 		}
 
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			assert ast2 != null;
+			assert getAst1() != null;
+			assert getAst2() != null;
 			// get the array var
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			// get the index
-			int ast2_result = ast2.populateTuples(tuples);
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 			tuples.dereferenceArray();
 			popSourceLineNumber(tuples);
@@ -4261,11 +4325,11 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
-			assert ast2 != null;
-			int ast2_result = ast2.populateTuples(tuples);
+			assert getAst2() != null;
+			int ast2_result = getAst2().populateTuples(tuples);
 			assert ast2_result == 1;
 			tuples.conditionPair();
 			popSourceLineNumber(tuples);
@@ -4282,7 +4346,7 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.castInt();
 			popSourceLineNumber(tuples);
@@ -4299,7 +4363,7 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.castDouble();
 			popSourceLineNumber(tuples);
@@ -4316,7 +4380,7 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			tuples.castString();
 			popSourceLineNumber(tuples);
@@ -4328,7 +4392,7 @@ public class AwkParser {
 
 		private Begin_AST() {
 			super();
-			is_begin = true;
+			setBeginFlag(true);
 		}
 
 		@Override
@@ -4344,7 +4408,7 @@ public class AwkParser {
 
 		private End_AST() {
 			super();
-			is_end = true;
+			setEndFlag(true);
 		}
 
 		@Override
@@ -4365,22 +4429,22 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			assert getAst1() != null;
+			if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				tuples.inc(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr_ast = (ArrayReference_AST) ast1;
-				ID_AST id_ast = (ID_AST) arr_ast.ast1;
+			} else if (getAst1() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr_ast = (ArrayReference_AST) getAst1();
+				ID_AST id_ast = (ID_AST) arr_ast.getAst1();
 				assert id_ast != null;
-				assert arr_ast.ast2 != null;
-				int arr_ast2_result = arr_ast.ast2.populateTuples(tuples);
+				assert arr_ast.getAst2() != null;
+				int arr_ast2_result = arr_ast.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				tuples.incArrayRef(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast1;
-				assert dollar_expr.ast1 != null;
-				int ast1_result = dollar_expr.ast1.populateTuples(tuples);
+			} else if (getAst1() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst1();
+				assert dollar_expr.getAst1() != null;
+				int ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				// OPTIMIATION: duplicate the x in $x here
 				// so that it is not evaluated again
@@ -4395,11 +4459,11 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1; // NOTE, short-circuit return here!
 			} else {
-				throw new NotImplementedError("unhandled preinc for " + ast1);
+				throw new NotImplementedError("unhandled preinc for " + getAst1());
 			}
 			// else
-			// assert false : "cannot refer for pre_inc to "+ast1;
-			int ast1_result = ast1.populateTuples(tuples);
+			// assert false : "cannot refer for pre_inc to "+getAst1();
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			popSourceLineNumber(tuples);
 			return 1;
@@ -4415,22 +4479,22 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			assert getAst1() != null;
+			if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				tuples.dec(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr_ast = (ArrayReference_AST) ast1;
-				ID_AST id_ast = (ID_AST) arr_ast.ast1;
+			} else if (getAst1() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr_ast = (ArrayReference_AST) getAst1();
+				ID_AST id_ast = (ID_AST) arr_ast.getAst1();
 				assert id_ast != null;
-				assert arr_ast.ast2 != null;
-				int arr_ast2_result = arr_ast.ast2.populateTuples(tuples);
+				assert arr_ast.getAst2() != null;
+				int arr_ast2_result = arr_ast.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				tuples.decArrayRef(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast1;
-				assert dollar_expr.ast1 != null;
-				int ast1_result = dollar_expr.ast1.populateTuples(tuples);
+			} else if (getAst1() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst1();
+				assert dollar_expr.getAst1() != null;
+				int ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				// OPTIMIATION: duplicate the x in $x here
 				// so that it is not evaluated again
@@ -4445,9 +4509,9 @@ public class AwkParser {
 				popSourceLineNumber(tuples);
 				return 1; // NOTE, short-circuit return here!
 			} else {
-				throw new NotImplementedError("unhandled predec for " + ast1);
+				throw new NotImplementedError("unhandled predec for " + getAst1());
 			}
-			int ast1_result = ast1.populateTuples(tuples);
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
 			popSourceLineNumber(tuples);
 			return 1;
@@ -4463,28 +4527,28 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
-			if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				tuples.postInc(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr_ast = (ArrayReference_AST) ast1;
-				ID_AST id_ast = (ID_AST) arr_ast.ast1;
+			} else if (getAst1() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr_ast = (ArrayReference_AST) getAst1();
+				ID_AST id_ast = (ID_AST) arr_ast.getAst1();
 				assert id_ast != null;
-				assert arr_ast.ast2 != null;
-				int arr_ast2_result = arr_ast.ast2.populateTuples(tuples);
+				assert arr_ast.getAst2() != null;
+				int arr_ast2_result = arr_ast.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				tuples.incArrayRef(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast1;
-				assert dollar_expr.ast1 != null;
-				int dollarast_ast1_result = dollar_expr.ast1.populateTuples(tuples);
+			} else if (getAst1() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst1();
+				assert dollar_expr.getAst1() != null;
+				int dollarast_ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 				assert dollarast_ast1_result == 1;
 				tuples.incDollarRef();
 			} else {
-				throw new NotImplementedError("unhandled postinc for " + ast1);
+				throw new NotImplementedError("unhandled postinc for " + getAst1());
 			}
 			popSourceLineNumber(tuples);
 			return 1;
@@ -4500,28 +4564,28 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
-			int ast1_result = ast1.populateTuples(tuples);
+			assert getAst1() != null;
+			int ast1_result = getAst1().populateTuples(tuples);
 			assert ast1_result == 1;
-			if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				tuples.postDec(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr_ast = (ArrayReference_AST) ast1;
-				ID_AST id_ast = (ID_AST) arr_ast.ast1;
+			} else if (getAst1() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr_ast = (ArrayReference_AST) getAst1();
+				ID_AST id_ast = (ID_AST) arr_ast.getAst1();
 				assert id_ast != null;
-				assert arr_ast.ast2 != null;
-				int arr_ast2_result = arr_ast.ast2.populateTuples(tuples);
+				assert arr_ast.getAst2() != null;
+				int arr_ast2_result = arr_ast.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				tuples.decArrayRef(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast1;
-				assert dollar_expr.ast1 != null;
-				int dollarast_ast1_result = dollar_expr.ast1.populateTuples(tuples);
+			} else if (getAst1() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst1();
+				assert dollar_expr.getAst1() != null;
+				int dollarast_ast1_result = dollar_expr.getAst1().populateTuples(tuples);
 				assert dollarast_ast1_result == 1;
 				tuples.decDollarRef();
 			} else {
-				throw new NotImplementedError("unhandled postinc for " + ast1);
+				throw new NotImplementedError("unhandled postinc for " + getAst1());
 			}
 			popSourceLineNumber(tuples);
 			return 1;
@@ -4542,18 +4606,18 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 
 			int param_count;
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				param_count = 0;
 			} else {
-				param_count = ast1.populateTuples(tuples);
+				param_count = getAst1().populateTuples(tuples);
 				assert param_count >= 0;
 				if (param_count == 0) {
 					throw new SemanticException("Cannot print the result. The expression doesn't return anything.");
 				}
 			}
 
-			if (ast2 != null) {
-				int ast2_result = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 1;
 			}
 
@@ -4586,24 +4650,24 @@ public class AwkParser {
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
 			int param_count;
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				param_count = 0;
 			} else {
 				/// Query for the extension.
 				JawkExtension extension = extensions.get(extensionKeyword);
-				int arg_count = countParams((FunctionCallParamList_AST) ast1);
+				int arg_count = countParams((FunctionCallParamList_AST) getAst1());
 				/// Get all required assoc array parameters:
 				int[] req_array_idxs = extension.getAssocArrayParameterPositions(extensionKeyword, arg_count);
 				assert req_array_idxs != null;
 
 				for (int idx : req_array_idxs) {
-					AST param_ast = getParamAst((FunctionCallParamList_AST) ast1, idx);
-					assert ast1 instanceof FunctionCallParamList_AST;
+					AST param_ast = getParamAst((FunctionCallParamList_AST) getAst1(), idx);
+					assert getAst1() instanceof FunctionCallParamList_AST;
 					// if the parameter is an ID_AST...
-					if (param_ast.ast1 instanceof ID_AST) {
+					if (param_ast.getAst1() instanceof ID_AST) {
 						// then force it to be an array,
 						// or complain if it is already tagged as a scalar
-						ID_AST id_ast = (ID_AST) param_ast.ast1;
+						ID_AST id_ast = (ID_AST) param_ast.getAst1();
 						if (id_ast.isScalar()) {
 							throw new SemanticException(
 									"Extension '"
@@ -4616,7 +4680,7 @@ public class AwkParser {
 					}
 				}
 
-				param_count = ast1.populateTuples(tuples);
+				param_count = getAst1().populateTuples(tuples);
 				assert param_count >= 0;
 			}
 			// is_initial == true ::
@@ -4624,10 +4688,10 @@ public class AwkParser {
 			// of another extension
 			// true iff Extension | FunctionCallParam | FunctionCallParam | etc.
 			boolean is_initial;
-			if (parent instanceof FunctionCallParamList_AST) {
-				AST ptr = parent;
+			if (getParent() instanceof FunctionCallParamList_AST) {
+				AST ptr = getParent();
 				while (ptr instanceof FunctionCallParamList_AST) {
-					ptr = ptr.parent;
+					ptr = ptr.getParent();
 				}
 				is_initial = !(ptr instanceof Extension_AST);
 			} else {
@@ -4641,7 +4705,7 @@ public class AwkParser {
 
 		private AST getParamAst(FunctionCallParamList_AST p_ast, int pos) {
 			for (int i = 0; i < pos; ++i) {
-				p_ast = (FunctionCallParamList_AST) p_ast.ast2;
+				p_ast = (FunctionCallParamList_AST) p_ast.getAst2();
 				if (p_ast == null) {
 					throw new SemanticException("More arguments required for assoc array parameter position specification.");
 				}
@@ -4652,7 +4716,7 @@ public class AwkParser {
 		private int countParams(FunctionCallParamList_AST p_ast) {
 			int cnt = 0;
 			while (p_ast != null) {
-				p_ast = (FunctionCallParamList_AST) p_ast.ast2;
+				p_ast = (FunctionCallParamList_AST) p_ast.getAst2();
 				++cnt;
 			}
 			return cnt;
@@ -4678,18 +4742,18 @@ public class AwkParser {
 			pushSourceLineNumber(tuples);
 
 			int param_count;
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				param_count = 0;
 			} else {
-				param_count = ast1.populateTuples(tuples);
+				param_count = getAst1().populateTuples(tuples);
 				assert param_count >= 0;
 				if (param_count == 0) {
 					throw new SemanticException("Cannot printf the result. The expression doesn't return anything.");
 				}
 			}
 
-			if (ast2 != null) {
-				int ast2_result = ast2.populateTuples(tuples);
+			if (getAst2() != null) {
+				int ast2_result = getAst2().populateTuples(tuples);
 				assert ast2_result == 1;
 			}
 
@@ -4717,16 +4781,16 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (ast1 != null) {
-				int ast1_result = ast1.populateTuples(tuples);
+			if (getAst1() != null) {
+				int ast1_result = getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
-				// stack has ast1 (i.e., "command")
+				// stack has getAst1() (i.e., "command")
 				tuples.useAsCommandInput();
-			} else if (ast3 != null) {
-				// getline ... < ast3
-				int ast3_result = ast3.populateTuples(tuples);
+			} else if (getAst3() != null) {
+				// getline ... < getAst3()
+				int ast3_result = getAst3().populateTuples(tuples);
 				assert ast3_result == 1;
-				// stack has ast3 (i.e., "filename")
+				// stack has getAst3() (i.e., "filename")
 				tuples.useAsFileInput();
 			} else {
 				tuples.getlineInput();
@@ -4734,35 +4798,35 @@ public class AwkParser {
 			// 2 resultant values on the stack!
 			// 2nd - -1/0/1 for io-err,eof,success
 			// 1st(top) - the input
-			if (ast2 == null) {
+			if (getAst2() == null) {
 				tuples.assignAsInput();
 				// stack still has the input, to be popped below...
 				// (all assignment results are placed on the stack)
-			} else if (ast2 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast2;
+			} else if (getAst2() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst2();
 				tuples.assign(id_ast.offset, id_ast.is_global);
 				if (id_ast.id.equals("RS")) {
 					tuples.applyRS();
 				}
-			} else if (ast2 instanceof ArrayReference_AST) {
-				ArrayReference_AST arr = (ArrayReference_AST) ast2;
+			} else if (getAst2() instanceof ArrayReference_AST) {
+				ArrayReference_AST arr = (ArrayReference_AST) getAst2();
 				// push the index
-				assert arr.ast2 != null;
-				int arr_ast2_result = arr.ast2.populateTuples(tuples);
+				assert arr.getAst2() != null;
+				int arr_ast2_result = arr.getAst2().populateTuples(tuples);
 				assert arr_ast2_result == 1;
 				// push the array ref itself
-				ID_AST id_ast = (ID_AST) arr.ast1;
+				ID_AST id_ast = (ID_AST) arr.getAst1();
 				tuples.assignArray(id_ast.offset, id_ast.is_global);
-			} else if (ast2 instanceof DollarExpression_AST) {
-				DollarExpression_AST dollar_expr = (DollarExpression_AST) ast2;
-				if (dollar_expr.ast2 != null) {
-					int ast2_result = dollar_expr.ast2.populateTuples(tuples);
+			} else if (getAst2() instanceof DollarExpression_AST) {
+				DollarExpression_AST dollar_expr = (DollarExpression_AST) getAst2();
+				if (dollar_expr.getAst2() != null) {
+					int ast2_result = dollar_expr.getAst2().populateTuples(tuples);
 					assert ast2_result == 1;
 				}
 				// stack contains eval of dollar arg
 				tuples.assignAsInputField();
 			} else {
-				throw new SemanticException("Cannot getline into a " + ast2);
+				throw new SemanticException("Cannot getline into a " + getAst2());
 			}
 			// get rid of value left by the assignment
 			tuples.pop();
@@ -4785,8 +4849,8 @@ public class AwkParser {
 			if (returnable == null) {
 				throw new SemanticException("Cannot use return here.");
 			}
-			if (ast1 != null) {
-				int ast1_result = ast1.populateTuples(tuples);
+			if (getAst1() != null) {
+				int ast1_result = getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				tuples.setReturnResult();
 			}
@@ -4805,8 +4869,8 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (ast1 != null) {
-				int ast1_result = ast1.populateTuples(tuples);
+			if (getAst1() != null) {
+				int ast1_result = getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				tuples.exitWithCode();
 			} else {
@@ -4826,29 +4890,29 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			assert ast1 != null;
+			assert getAst1() != null;
 
-			if (ast1 instanceof ArrayReference_AST) {
-				assert ast1.ast1 != null; // a in a[b]
-				assert ast1.ast2 != null; // b in a[b]
-				ID_AST id_ast = (ID_AST) ast1.ast1;
+			if (getAst1() instanceof ArrayReference_AST) {
+				assert getAst1().getAst1() != null; // a in a[b]
+				assert getAst1().getAst2() != null; // b in a[b]
+				ID_AST id_ast = (ID_AST) getAst1().getAst1();
 				if (id_ast.isScalar()) {
 					throw new SemanticException("delete: Cannot use a scalar as an array.");
 				}
 				id_ast.setArray(true);
-				int idx_result = ast1.ast2.populateTuples(tuples);
+				int idx_result = getAst1().getAst2().populateTuples(tuples);
 				assert idx_result == 1;
 				// idx on the stack
 				tuples.deleteArrayElement(id_ast.offset, id_ast.is_global);
-			} else if (ast1 instanceof ID_AST) {
-				ID_AST id_ast = (ID_AST) ast1;
+			} else if (getAst1() instanceof ID_AST) {
+				ID_AST id_ast = (ID_AST) getAst1();
 				if (id_ast.isScalar()) {
 					throw new SemanticException("delete: Cannot delete a scalar.");
 				}
 				id_ast.setArray(true);
 				tuples.deleteArray(id_ast.offset, id_ast.is_global);
 			} else {
-				throw new Error("Should never reach here : delete for " + ast1);
+				throw new Error("Should never reach here : delete for " + getAst1());
 			}
 
 			popSourceLineNumber(tuples);
@@ -4881,10 +4945,10 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				tuples.sleep(0);
 			} else {
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				assert ast1_result == 1;
 				tuples.sleep(ast1_result);
 			}
@@ -4902,23 +4966,23 @@ public class AwkParser {
 		@Override
 		public int populateTuples(AwkTuples tuples) {
 			pushSourceLineNumber(tuples);
-			if (ast1 == null) {
+			if (getAst1() == null) {
 				tuples.dump(0);
 			} else {
-				assert ast1 instanceof FunctionCallParamList_AST;
-				AST ptr = ast1;
+				assert getAst1() instanceof FunctionCallParamList_AST;
+				AST ptr = getAst1();
 				while (ptr != null) {
-					if (!(ptr.ast1 instanceof ID_AST)) {
+					if (!(ptr.getAst1() instanceof ID_AST)) {
 						throw new SemanticException("ID required for argument(s) to _dump");
 					}
-					ID_AST id_ast = (ID_AST) ptr.ast1;
+					ID_AST id_ast = (ID_AST) ptr.getAst1();
 					if (id_ast.isScalar()) {
 						throw new SemanticException("_dump: Cannot use a scalar as an argument.");
 					}
 					id_ast.setArray(true);
-					ptr = ptr.ast2;
+					ptr = ptr.getAst2();
 				}
-				int ast1_result = ast1.populateTuples(tuples);
+				int ast1_result = getAst1().populateTuples(tuples);
 				tuples.dump(ast1_result);
 			}
 			popSourceLineNumber(tuples);


### PR DESCRIPTION
## Summary
- restrict `AwkParser.AST` member visibility
- add accessor methods for AST relationships and flags
- update subclasses to use the new accessors

## Testing
- `mvn formatter:format`
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_b_683dc009c214832183af0bfab253910e