### PR TITLE
Fix for-loop newline and pow assignment

### DIFF
--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -695,6 +695,11 @@ public class AwkParser {
 				return token;
 			} else if (c == '*') {
 				read();
+				if (c == '=') {
+					read();
+					token = POW_EQ;
+					return token;
+				}
 				token = POW;
 				return token;
 			}
@@ -1857,6 +1862,7 @@ public class AwkParser {
 
 		if (token == SEMICOLON) {
 			lexer();
+			optNewline();
 		} else {
 			throw new ParserException("Expecting ;. Got " + toTokenString(token) + ": " + text);
 		}
@@ -1866,6 +1872,7 @@ public class AwkParser {
 		}
 		if (token == SEMICOLON) {
 			lexer();
+			optNewline();
 		} else {
 			throw new ParserException("Expecting ;. Got " + toTokenString(token) + ": " + text);
 		}

--- a/src/test/java/org/metricshub/jawk/AwkParserTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkParserTest.java
@@ -102,6 +102,12 @@ public class AwkParserTest {
 	}
 
 	@Test
+	public void testPowAssignment() throws Exception {
+		assertEquals("^= must be supported", "4\n", runAwk("BEGIN { n = 2; n ^= 2; print n }", null));
+		assertEquals("**= must be supported", "4\n", runAwk("BEGIN { n = 2; n **= 2; print n }", null));
+	}
+
+	@Test
 	public void testOperatorPrecedence() throws Exception {
 		assertEquals(
 				"$a precedes a++",


### PR DESCRIPTION
## Summary
- allow `**=` syntax
- permit newline after semicolons in `for` header
- test power assignment operators

## Testing
- `mvn --offline test`

------
https://chatgpt.com/codex/tasks/task_b_683dff4c931c83218add7aac8ff0027f