### PR TITLE
Allow getline without lvalue

### DIFF
--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -1995,9 +1995,6 @@ public class AwkParser {
 	AST GETLINE_EXPRESSION(AST pipeExpr, boolean notInPrintRoot, boolean allowInKeyword) throws IOException {
 		expectKeyword("getline");
 		AST lvalue = LVALUE(notInPrintRoot, allowInKeyword);
-		if (lvalue == null) {
-			throw new ParserException("Missing lvalue in getline expression");
-		}
 		if (token == LT) {
 			lexer();
 			AST assignmentExpr = ASSIGNMENT_EXPRESSION(notInPrintRoot, allowInKeyword, false); // do NOT allow multidim

--- a/src/test/java/org/metricshub/jawk/AwkTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTest.java
@@ -542,4 +542,10 @@ public class AwkTest {
 				"42\n\n",
 				runAwk("BEGIN { SUBSEP=\"@\"; idx = 1 SUBSEP 2; a[idx]=42; SUBSEP=\":\"; print a[idx]; print a[1,2]; }", null));
 	}
+
+	@Test
+	public void testGetlineDefaultVariable() throws Exception {
+		String script = "BEGIN { while (getline && n++ < 2) print; exit }";
+		assertEquals("a\nb\n", runAwk(script, "a\nb\nc\n"));
+	}
 }


### PR DESCRIPTION
## Summary
- relax parser to allow `getline` without assigning to a variable
- assign to `$0` when no lvalue is provided
- add a regression test for `getline` defaulting to `$0`

## Testing
- `mvn --offline test`

------
https://chatgpt.com/codex/tasks/task_b_683dff1941a08321954c4f9b48d687d1