### PR TITLE
Fix Javadoc param name in JRT

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -1491,7 +1491,7 @@ public class JRT {
 	 * applyRS.
 	 * </p>
 	 *
-	 * @param rs_obj a {@link java.lang.Object} object
+	 * @param rsObj a {@link java.lang.Object} object
 	 */
 	public void applyRS(Object rsObj) {
 		// if (rsObj.toString().equals(BLANK))


### PR DESCRIPTION
## Summary
- fix Javadoc comment for `applyRS` parameter
- update formatting, licenses, and Javadoc

## Testing
- `mvn --offline formatter:format license:update-file-header javadoc:javadoc`

------
https://chatgpt.com/codex/tasks/task_b_683dfed93ae48321940ae9845527a356