### PR TITLE
Fix numeric detection when printing fields

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -94,6 +94,10 @@ public class JRT {
 
 	private static final boolean IS_WINDOWS = System.getProperty("os.name").indexOf("Windows") >= 0;
 
+	/** Regular expression to detect numeric strings (AWK semantics). */
+	private static final Pattern NUMERIC_PATTERN = Pattern
+			.compile("^[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?$");
+
 	private VariableManager vm;
 
 	private Map<String, Process> outputProcesses = new HashMap<String, Process>();
@@ -219,10 +223,13 @@ public class JRT {
 		// it to a Double. Because if it's a literal representation of a number,
 		// we will need to display it as a number ("12.00" --> 12)
 		if (!(o instanceof Number)) {
-			try {
-				o = Double.parseDouble(o.toString());
-			} catch (NumberFormatException e) {
-				LOG.debug("Failed to parse number", e);
+			String s = o.toString();
+			if (NUMERIC_PATTERN.matcher(s).matches()) {
+				try {
+					o = Double.parseDouble(s);
+				} catch (NumberFormatException e) {
+					LOG.debug("Failed to parse number", e);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- avoid treating strings like `4d` as numbers by introducing a numeric pattern
- only parse to `Double` when the whole string matches this pattern

## Testing
- `mvn -o formatter:format license:update-file-header`
- `mvn -o verify site`


------
https://chatgpt.com/codex/tasks/task_b_683f751e274083218be9170312aa6a75