### PR TITLE
Fix array deletion with numeric keys

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/AssocArray.java
+++ b/src/main/java/org/metricshub/jawk/jrt/AssocArray.java
@@ -261,7 +261,22 @@ public class AssocArray implements Comparator<Object> {
 	 * @return the value of the entry before it was removed
 	 */
 	public Object remove(Object key) {
-		return map.remove(key);
+		if (key == null || key instanceof UninitializedObject) {
+			key = (long) 0;
+		}
+		Object result = map.remove(key);
+		if (result != null) {
+			return result;
+		}
+
+		try {
+			long iKey = Long.parseLong(key.toString());
+			return map.remove(iKey);
+		} catch (Exception e) {
+			LOG.debug("Key parse failure", e);
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/test/java/org/metricshub/jawk/AssocArrayTest.java
+++ b/src/test/java/org/metricshub/jawk/AssocArrayTest.java
@@ -1,0 +1,36 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.metricshub.jawk.jrt.AssocArray;
+
+public class AssocArrayTest {
+
+	@Test
+	public void testRemoveNumericStringKey() {
+		AssocArray array = new AssocArray(false);
+		array.put(1L, "one");
+
+		assertEquals("one", array.remove("1"));
+		assertFalse(array.isIn(1L));
+	}
+
+	@Test
+	public void testRemoveNumericKeyFromString() {
+		AssocArray array = new AssocArray(false);
+		array.put("2", "two");
+
+		assertEquals("two", array.remove(2L));
+		assertFalse(array.isIn("2"));
+	}
+
+	@Test
+	public void testRemoveMissingKey() {
+		AssocArray array = new AssocArray(false);
+		array.put(1, "one");
+
+		assertNull(array.remove(3L));
+		assertTrue(array.isIn(1L));
+	}
+}


### PR DESCRIPTION
## Summary
- handle numeric keys in AssocArray.remove
- add tests for AssocArray removal
- run code formatter and update license headers
- `mvn verify` *(fails: PatternSyntaxException)*

## Testing
- `mvn formatter:format`
- `mvn license:update-file-header`
- `mvn verify` *(fails: PatternSyntaxException)*

------
https://chatgpt.com/codex/tasks/task_b_6840506a6b88832196a9895d8518d960