### PR TITLE
Fix early exit logic

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -1869,7 +1869,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 					throwExitException = true;
 
 					// If in BEGIN or in a rule, jump to the END section
-					if (!withinEndBlocks) {
+					if (!withinEndBlocks && exitAddress != null) {
 						// clear runtime stack
 						runtimeStack.popAllFrames();
 						// clear operand stack


### PR DESCRIPTION
## Summary
- exit gracefully if END block doesn't exist
- run Maven formatter and license header update

## Testing
- `mvn test`
- `mvn verify site`


------
https://chatgpt.com/codex/tasks/task_b_68408dd0b6ac83219a4dcab066179f12