### PR TITLE
Fix FS parsing for empty lines

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -771,23 +771,28 @@ public class JRT {
 	 */
 	public void jrtParseFields() {
 		String fsString = vm.getFS().toString();
-		Enumeration<Object> tokenizer;
-		if (fsString.equals(" ")) {
-			tokenizer = new StringTokenizer(inputLine);
-		} else if (fsString.length() == 1) {
-			tokenizer = new SingleCharacterTokenizer(inputLine, fsString.charAt(0));
-		} else if (fsString.equals("")) {
-			tokenizer = new CharacterTokenizer(inputLine);
-		} else {
-			tokenizer = new RegexTokenizer(inputLine, fsString);
-		}
-
 		assert inputLine != null;
+
 		inputFields.clear();
 		inputFields.add(inputLine); // $0
-		while (tokenizer.hasMoreElements()) {
-			inputFields.add((String) tokenizer.nextElement());
+
+		if (!inputLine.isEmpty()) {
+			Enumeration<Object> tokenizer;
+			if (fsString.equals(" ")) {
+				tokenizer = new StringTokenizer(inputLine);
+			} else if (fsString.length() == 1) {
+				tokenizer = new SingleCharacterTokenizer(inputLine, fsString.charAt(0));
+			} else if (fsString.equals("")) {
+				tokenizer = new CharacterTokenizer(inputLine);
+			} else {
+				tokenizer = new RegexTokenizer(inputLine, fsString);
+			}
+
+			while (tokenizer.hasMoreElements()) {
+				inputFields.add((String) tokenizer.nextElement());
+			}
 		}
+
 		// recalc NF
 		recalculateNF();
 	}


### PR DESCRIPTION
## Summary
- fix parsing when field separator FS is set and the record is empty
- run `mvn formatter:format`
- update license headers

## Testing
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_68408dbe9e7c8321895cc6e5e1d20a19