### PR TITLE
Fix pipe output handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -179,6 +179,9 @@ public class AVM implements AwkInterpreter, VariableManager {
 		}
 
 		jrt = new JRT(this); // this = VariableManager
+		if (settings != null) {
+			jrt.setStreams(settings.getOutputStream(), System.err);
+		}
 		for (JawkExtension ext : this.extensions.values()) {
 			ext.init(this, jrt, settings); // this = VariableManager
 		}
@@ -1242,7 +1245,7 @@ public class AVM implements AwkInterpreter, VariableManager {
 				case AwkTuples.SYSTEM: {
 					// stack[0] = command string
 					String s = JRT.toAwkString(pop(), getCONVFMT().toString(), locale);
-					push(JRT.jrtSystem(s));
+					push(jrt.jrtSystem(s));
 					position.next();
 					break;
 				}

--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -99,6 +99,10 @@ public class JRT {
 
 	private Map<String, Process> outputProcesses = new HashMap<String, Process>();
 	private Map<String, PrintStream> outputStreams = new HashMap<String, PrintStream>();
+	/** PrintStream used for command output */
+	private PrintStream output = System.out;
+	/** PrintStream used for command error output */
+	private PrintStream error = System.err;
 
 	// Partitioning reader for stdin.
 	private PartitioningReader partitioningReader = null;
@@ -129,6 +133,17 @@ public class JRT {
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "JRT must hold the provided VariableManager for later use")
 	public JRT(VariableManager vm) {
 		this.vm = vm;
+	}
+
+	/**
+	 * Sets the streams for spawned command output and error.
+	 *
+	 * @param ps PrintStream to send command output to
+	 * @param err PrintStream to send command error output to
+	 */
+	public void setStreams(PrintStream ps, PrintStream err) {
+		output = ps == null ? System.out : ps;
+		error = err == null ? System.err : err;
 	}
 
 	/**
@@ -1091,16 +1106,15 @@ public class JRT {
 			Process p;
 			try {
 				p = spawnProcess(cmd);
-				DataPump.dump(cmd, p.getErrorStream(), System.err);
-				DataPump.dump(cmd, p.getInputStream(), System.out);
+				DataPump.dump(cmd, p.getErrorStream(), error);
+				DataPump.dump(cmd, p.getInputStream(), output);
 			} catch (IOException ioe) {
 				throw new AwkRuntimeException("Can't spawn " + cmd + ": " + ioe);
 			}
 			outputProcesses.put(cmd, p);
 			try {
 				ps = new PrintStream(p.getOutputStream(), true, StandardCharsets.UTF_8.name()); // true
-				// =
-				// auto-flush
+				// = auto-flush
 				outputStreams.put(cmd, ps);
 			} catch (java.io.UnsupportedEncodingException e) {
 				throw new IllegalStateException(e);
@@ -1243,13 +1257,13 @@ public class JRT {
 	 * @return Integer(return_code) of the created
 	 *         process. Integer(-1) is returned on an IO error.
 	 */
-	public static Integer jrtSystem(String cmd) {
+	public Integer jrtSystem(String cmd) {
 		try {
 			Process p = spawnProcess(cmd);
 			// no input to this process!
 			p.getOutputStream().close();
-			DataPump.dump(cmd, p.getErrorStream(), System.err);
-			DataPump.dump(cmd, p.getInputStream(), System.out);
+			DataPump.dump(cmd, p.getErrorStream(), error);
+			DataPump.dump(cmd, p.getInputStream(), output);
 			try {
 				int retcode = p.waitFor();
 				return Integer.valueOf(retcode);


### PR DESCRIPTION
## Summary
- store AWK output/error streams in JRT
- rely on stored streams for spawned commands and system()
- simplify AVM calls for pipe and system commands

## Testing
- `mvn --offline formatter:format`
- `mvn --offline -Dtest=org.metricshub.jawk.BwkTTest#test\[BWK.t\ t.in1\] -DfailIfNoTests=false test`
- `mvn --offline verify`


------
https://chatgpt.com/codex/tasks/task_b_68408e0437148321948f9ab1f2f471f2