### PR TITLE
Fix split count and whitespace regex handling

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -572,6 +572,7 @@ public class JRT {
 		while (e.hasMoreElements()) {
 			aa.put(++cnt, e.nextElement());
 		}
+		aa.put(0L, Integer.valueOf(cnt));
 		return cnt;
 	}
 

--- a/src/main/java/org/metricshub/jawk/jrt/RegexTokenizer.java
+++ b/src/main/java/org/metricshub/jawk/jrt/RegexTokenizer.java
@@ -23,6 +23,9 @@ package org.metricshub.jawk.jrt;
  */
 
 import java.util.Enumeration;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 /**
  * Similar to StringTokenizer, except that tokens are delimited
@@ -43,7 +46,20 @@ public class RegexTokenizer implements Enumeration<Object> {
 	 *        within the input string.
 	 */
 	public RegexTokenizer(String input, String delimitterRegexPattern) {
-		array = input.split(delimitterRegexPattern, -2);
+		ArrayList<String> fields = new ArrayList<>();
+		Pattern pattern = Pattern.compile(delimitterRegexPattern);
+		Matcher matcher = pattern.matcher(input);
+		int last = 0;
+		while (matcher.find()) {
+			if (matcher.start() > last) {
+				fields.add(input.substring(last, matcher.start()));
+			}
+			last = matcher.end();
+		}
+		if (last < input.length()) {
+			fields.add(input.substring(last));
+		}
+		array = fields.toArray(new String[0]);
 	}
 
 	/** {@inheritDoc} */

--- a/src/test/java/org/metricshub/jawk/JRTTest.java
+++ b/src/test/java/org/metricshub/jawk/JRTTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.metricshub.jawk.intermediate.UninitializedObject;
+import java.util.Locale;
+import org.metricshub.jawk.jrt.AssocArray;
 import org.metricshub.jawk.jrt.JRT;
 
 public class JRTTest {
@@ -101,5 +103,22 @@ public class JRTTest {
 		assertEquals("a\\\\&", JRT.prepareReplacement("a\\\\\\&"));
 		assertEquals("", JRT.prepareReplacement(""));
 		assertEquals("", JRT.prepareReplacement(null));
+	}
+
+	@Test
+	public void testSplitSetsFieldZero() {
+		AssocArray aa = new AssocArray(false);
+		int n = JRT.split(aa, "a b", "%.6g", Locale.US);
+		assertEquals(2, n);
+		assertEquals(2, aa.get(0));
+	}
+
+	@Test
+	public void testSplitRegexWhitespace() {
+		AssocArray aa = new AssocArray(false);
+		int n = JRT.split("[ \t]+", aa, " 9853   shen", "%.6g", Locale.US);
+		assertEquals(2, n);
+		assertEquals("9853", aa.get(1));
+		assertEquals("shen", aa.get(2));
 	}
 }


### PR DESCRIPTION
## Summary
- ensure split assigns field count to index 0
- handle regex splitting like gawk
- cover split with regex and field 0 in unit tests

## Testing
- `mvn --offline test`
- `mvn --offline verify site`


------
https://chatgpt.com/codex/tasks/task_b_6842bf4e2b84832192a9106a499be391