### PR TITLE
Fix ORS flushing in AVM

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -2136,10 +2136,9 @@ public class AVM implements AwkInterpreter, VariableManager {
 			}
 			ps.print(getORS().toString());
 		}
-		// for now, since we are not using Process.waitFor()
-		if (IS_WINDOWS) {
-			ps.flush();
-		}
+		// always flush to ensure ORS is written even when it does not
+		// contain a newline character
+		ps.flush();
 	}
 
 	private void printfTo(PrintStream ps, long numArgs) {


### PR DESCRIPTION
## Summary
- flush output streams after every print call so ORS is properly written

## Testing
- `mvn --offline test`

------
https://chatgpt.com/codex/tasks/task_b_6842bf324fe88321b12e0ecf318cdfca