### PR TITLE
Fix deterministic rand() sequence

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
+import org.metricshub.jawk.jrt.BSDRandom;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -207,8 +207,18 @@ public class AVM implements AwkInterpreter, VariableManager {
 	private static final Integer ZERO = Integer.valueOf(0);
 	private static final Integer ONE = Integer.valueOf(1);
 
-	private final Random randomNumberGenerator = new Random();
-	private int oldseed;
+	/** Random number generator used for rand() */
+	private final BSDRandom randomNumberGenerator = new BSDRandom(1);
+
+	/**
+	 * Last seed value used with {@code srand()}.
+	 * <p>
+	 * The default seed for {@code rand()} in One True Awk is {@code 1}, so
+	 * we initialize {@code oldseed} with this value to mimic that
+	 * behaviour. This ensures deterministic sequences until the user
+	 * explicitly calls {@code srand()}.
+	 */
+	private int oldseed = 1;
 
 	private Address exitAddress = null;
 

--- a/src/main/java/org/metricshub/jawk/jrt/BSDRandom.java
+++ b/src/main/java/org/metricshub/jawk/jrt/BSDRandom.java
@@ -1,0 +1,80 @@
+package org.metricshub.jawk.jrt;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+/**
+ * Simple pseudo-random number generator compatible with the C library
+ * {@code random()} function.
+ */
+public class BSDRandom {
+
+	private static final int RAND_DEG = 31;
+	private static final int RAND_SEP = 3;
+	private final int[] state = new int[RAND_DEG];
+	private int fptr;
+	private int rptr;
+
+	/** Create a new generator with the specified seed. */
+	public BSDRandom(int seed) {
+		setSeed(seed);
+	}
+
+	/**
+	 * Seed the generator. A seed of {@code 0} is transformed to {@code 1}
+	 * as in the original implementation.
+	 */
+	public final void setSeed(int seed) {
+		if (seed == 0) {
+			seed = 1;
+		}
+		state[0] = seed;
+		for (int i = 1; i < RAND_DEG; i++) {
+			long val = 16807L * state[i - 1] % 2147483647L;
+			state[i] = (int) val;
+		}
+		fptr = RAND_SEP;
+		rptr = 0;
+		for (int i = 0; i < 10 * RAND_DEG; i++) {
+			nextInt();
+		}
+	}
+
+	private int nextInt() {
+		int val = state[fptr] + state[rptr];
+		state[fptr] = val;
+		if (++fptr >= RAND_DEG) {
+			fptr = 0;
+		}
+		if (++rptr >= RAND_DEG) {
+			rptr = 0;
+		}
+		return (val >>> 1) & 0x7fffffff;
+	}
+
+	/**
+	 * Return the next pseudo-random number in the range {@code [0.0,1.0)}.
+	 */
+	public double nextDouble() {
+		return ((double) nextInt()) / 2147483647.0;
+	}
+}

--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -44,7 +44,6 @@ import java.util.IllegalFormatException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -1507,8 +1506,8 @@ public class JRT {
 	 * @param seed a int
 	 * @return a {@link java.util.Random} object
 	 */
-	public static Random newRandom(int seed) {
-		return new Random(seed);
+	public static BSDRandom newRandom(int seed) {
+		return new BSDRandom(seed);
 	}
 
 	/**

--- a/src/test/java/org/metricshub/jawk/BSDRandomTest.java
+++ b/src/test/java/org/metricshub/jawk/BSDRandomTest.java
@@ -1,0 +1,32 @@
+package org.metricshub.jawk;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.metricshub.jawk.jrt.BSDRandom;
+
+/**
+ * Unit tests for {@link BSDRandom} verifying deterministic sequences.
+ */
+public class BSDRandomTest {
+
+	@Test
+	public void testDeterministicSequence() {
+		BSDRandom rng = new BSDRandom(1);
+		double[] expected = {
+				0.8401877171547095,
+				0.3943829268190930,
+				0.7830992237586059,
+				0.7984400334760733,
+				0.9116473579367843,
+				0.1975513692933840,
+				0.3352227557148890,
+				0.7682295948119040,
+				0.2777747108031878,
+				0.5539699557954305
+		};
+		for (double expectedValue : expected) {
+			assertEquals(expectedValue, rng.nextDouble(), 1e-15);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement BSDRandom compatible with C's `random()`
- use BSDRandom in AWK runtime to seed with 1 by default
- provide helper to create BSDRandom from JRT
- test deterministic output using BSDRandomTest

## Testing
- `mvn test`
- `mvn verify`
- `mvn site`


------
https://chatgpt.com/codex/tasks/task_b_6842bf430f3883219d968c4a20d55f88