### PR TITLE
Fix numeric conversion log spam

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -384,14 +384,18 @@ public class JRT {
 			try {
 				o1 = new BigDecimal(o1String).doubleValue();
 			} catch (NumberFormatException nfe) {
-				LOG.debug("Invalid number", nfe);
+				if (o1String.length() > 0) {
+					LOG.debug("Invalid number", nfe);
+				}
 			}
 		}
 		if (!(o2 instanceof Number)) {
 			try {
 				o2 = new BigDecimal(o2String).doubleValue();
 			} catch (NumberFormatException nfe) {
-				LOG.debug("Invalid number", nfe);
+				if (o2String.length() > 0) {
+					LOG.debug("Invalid number", nfe);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary
- avoid debug logs when comparing empty strings numerically

## Testing
- `mvn test -Dtest=JRTTest`
- `mvn -DskipTests verify`
- `mvn -DskipTests site`


------
https://chatgpt.com/codex/tasks/task_b_6842bf2df5048321ae1b25f62bc4ceaa