### PR TITLE
Fix ternary parsing inside print statements

### DIFF
--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -2008,8 +2008,23 @@ public class AwkParser {
 		boolean parens = token == OPEN_PAREN;
 		ParsedPrintStatement parsedPrintStatement = parsePrintStatement(parens);
 
+		AST params = parsedPrintStatement.getFuncParams();
+		if (parens
+				&& token == QUESTION_MARK
+				&& params instanceof FunctionCallParamListAst
+				&& ((FunctionCallParamListAst) params).getAst2() == null) {
+			AST condExpr = ((FunctionCallParamListAst) params).getAst1();
+			lexer();
+			AST trueBlock = TERNARY_EXPRESSION(true, true, true);
+			lexer(COLON);
+			AST falseBlock = TERNARY_EXPRESSION(true, true, true);
+			params = new FunctionCallParamListAst(
+					new TernaryExpressionAst(condExpr, trueBlock, falseBlock),
+					null);
+		}
+
 		return new PrintAst(
-				parsedPrintStatement.getFuncParams(),
+				params,
 				parsedPrintStatement.getOutputToken(),
 				parsedPrintStatement.getOutputExpr());
 	}
@@ -2019,8 +2034,23 @@ public class AwkParser {
 		boolean parens = token == OPEN_PAREN;
 		ParsedPrintStatement parsedPrintStatement = parsePrintStatement(parens);
 
+		AST params = parsedPrintStatement.getFuncParams();
+		if (parens
+				&& token == QUESTION_MARK
+				&& params instanceof FunctionCallParamListAst
+				&& ((FunctionCallParamListAst) params).getAst2() == null) {
+			AST condExpr = ((FunctionCallParamListAst) params).getAst1();
+			lexer();
+			AST trueBlock = TERNARY_EXPRESSION(true, true, true);
+			lexer(COLON);
+			AST falseBlock = TERNARY_EXPRESSION(true, true, true);
+			params = new FunctionCallParamListAst(
+					new TernaryExpressionAst(condExpr, trueBlock, falseBlock),
+					null);
+		}
+
 		return new PrintfAst(
-				parsedPrintStatement.getFuncParams(),
+				params,
 				parsedPrintStatement.getOutputToken(),
 				parsedPrintStatement.getOutputExpr());
 	}

--- a/src/test/java/org/metricshub/jawk/AwkParserTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkParserTest.java
@@ -86,6 +86,22 @@ public class AwkParserTest {
 	}
 
 	@Test
+	public void testNestedTernaryExpression() throws Exception {
+		assertEquals(
+				"Nested ternary must parse correctly",
+				"2",
+				evalAwk("1 ? 2 : 3 ? 4 : 5 "));
+	}
+
+	@Test
+	public void testTernaryAfterPrintParentheses() throws Exception {
+		assertEquals(
+				"Ternary after print parentheses must parse",
+				"20\n",
+				runAwk("BEGIN { print (1>2) ? 10 : 20 }", null));
+	}
+
+	@Test
 	public void testGron() throws Exception {
 		String gron = AwkTestHelper.readResource("/xonixx/gron.awk");
 		assertEquals("gron.awk must not trigger any parser exception", "json=[]\n", runAwk(gron, "[]"));


### PR DESCRIPTION
## Summary
- allow `print (expr) ? a : b` syntax by treating trailing `?` as part of expression
- mirror the same fix for `printf`
- test nested ternary expressions
- test ternary following `print` parentheses

## Testing
- `mvn test`
- `mvn verify`
- `mvn site`


------
https://chatgpt.com/codex/tasks/task_b_6842bf141dec8321adf1413065c2f48b