### PR TITLE
Fix array iteration for insertion order

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/AssocArray.java
+++ b/src/main/java/org/metricshub/jawk/jrt/AssocArray.java
@@ -159,7 +159,9 @@ public class AssocArray implements Comparator<Object> {
 	 */
 	public boolean isIn(Object key) {
 		if (key == null || key instanceof UninitializedObject) {
-			key = (long) 0;
+			// According to AWK semantics, an uninitialized index
+			// evaluates to the empty string, not numeric zero
+			key = "";
 		}
 
 		if (map.containsKey(key)) {
@@ -192,7 +194,8 @@ public class AssocArray implements Comparator<Object> {
 	 */
 	public Object get(Object key) {
 		if (key == null || key instanceof UninitializedObject) {
-			key = (long) 0;
+			// AWK evaluates an uninitialized subscript to the empty string
+			key = "";
 		}
 		Object result = map.get(key);
 		if (result != null) {
@@ -229,7 +232,7 @@ public class AssocArray implements Comparator<Object> {
 	 */
 	public Object put(Object key, Object value) {
 		if (key == null || key instanceof UninitializedObject) {
-			key = (long) 0;
+			key = "";
 		}
 		try {
 			// Save a primitive version
@@ -279,7 +282,7 @@ public class AssocArray implements Comparator<Object> {
 	 */
 	public Object remove(Object key) {
 		if (key == null || key instanceof UninitializedObject) {
-			key = (long) 0;
+			key = "";
 		}
 		Object result = map.remove(key);
 		if (result != null) {

--- a/src/test/java/org/metricshub/jawk/AssocArrayTest.java
+++ b/src/test/java/org/metricshub/jawk/AssocArrayTest.java
@@ -26,8 +26,8 @@ public class AssocArrayTest {
 		AssocArray array = new AssocArray(false);
 		array.put(0L, "zero");
 
-		assertTrue(array.isIn(null));
-		assertTrue(array.isIn(new UninitializedObject()));
+		assertFalse(array.isIn(null));
+		assertFalse(array.isIn(new UninitializedObject()));
 		assertEquals(1, array.keySet().size());
 	}
 
@@ -56,5 +56,19 @@ public class AssocArrayTest {
 
 		assertNull(array.remove(3L));
 		assertTrue(array.isIn(1L));
+	}
+
+	@Test
+	public void testUninitializedIndexUsesEmptyString() {
+		AssocArray idxArray = new AssocArray(false);
+		Object idx = idxArray.get(0L);
+		assertTrue(idx instanceof UninitializedObject);
+
+		AssocArray array = new AssocArray(false);
+		array.put("", "empty");
+		array.put(0L, "zero");
+
+		assertEquals("empty", array.get(idx));
+		assertEquals("zero", array.get(0L));
 	}
 }


### PR DESCRIPTION
## Summary
- handle uninitialized array indexes as empty string instead of numeric zero
- update tests for new behavior
- add test covering array key lookup with uninitialized index

## Testing
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_6842bf12237083218956ebd5fadf32e6