### PR TITLE
Ensure process output flushed on close

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -1195,16 +1195,17 @@ public class JRT {
 		outputProcesses.remove(cmd);
 		outputStreams.remove(cmd);
 		ps.close();
-		// if windows, let the process kill itself eventually
-		if (!IS_WINDOWS) {
-			try {
-				// causes a hard exit ?!
-				p.waitFor();
-				p.exitValue();
-			} catch (InterruptedException ie) {
-				throw new AwkRuntimeException("Caught exception while waiting for process exit: " + ie);
-			}
+		try {
+			// wait for the spawned process to finish to make sure
+			// all output has been flushed and captured
+			p.waitFor();
+			p.exitValue();
+		} catch (InterruptedException ie) {
+			throw new AwkRuntimeException(
+					"Caught exception while waiting for process exit: " + ie);
 		}
+		output.flush();
+		error.flush();
 		return true;
 	}
 
@@ -1233,16 +1234,17 @@ public class JRT {
 		commandProcesses.remove(cmd);
 		try {
 			pr.close();
-			// if windows, let the process kill itself eventually
-			if (!IS_WINDOWS) {
-				try {
-					// causes a hard die ?!
-					p.waitFor();
-					p.exitValue();
-				} catch (InterruptedException ie) {
-					throw new AwkRuntimeException("Caught exception while waiting for process exit: " + ie);
-				}
+			try {
+				// wait for the process to complete so that all
+				// data pumped from the command is captured
+				p.waitFor();
+				p.exitValue();
+			} catch (InterruptedException ie) {
+				throw new AwkRuntimeException(
+						"Caught exception while waiting for process exit: " + ie);
 			}
+			output.flush();
+			error.flush();
 			return true;
 		} catch (IOException ioe) {
 			return false;


### PR DESCRIPTION
## Summary
- wait for external process termination when closing output streams
- flush output/error streams after command finishes

## Testing
- `mvn formatter:format`
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_b_6842bf1d06d08321842020f83162549c