### PR TITLE
Ensure NF tracks field count correctly

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -2210,6 +2210,9 @@ public class AVM implements AwkInterpreter, VariableManager {
 		}
 		push(value);
 		runtimeStack.setVariable(l, value, isGlobal);
+		if (l == nfOffset && jrt != null && jrt.hasInputFields()) {
+			jrt.jrtSetNF(value);
+		}
 	}
 
 	/**

--- a/src/main/java/org/metricshub/jawk/jrt/JRT.java
+++ b/src/main/java/org/metricshub/jawk/jrt/JRT.java
@@ -816,6 +816,41 @@ public class JRT {
 		vm.setNF(Integer.valueOf(inputFields.size() - 1));
 	}
 
+	/**
+	 * @return true if at least one input field has been initialized.
+	 */
+	public boolean hasInputFields() {
+		return !inputFields.isEmpty();
+	}
+
+	/**
+	 * Adjust the current input field list and $0 when NF is updated by the
+	 * AWK script. Fields are either truncated or extended with empty values
+	 * so that {@code NF} truly reflects the number of fields.
+	 *
+	 * @param nfObj New value for NF
+	 */
+	public void jrtSetNF(Object nfObj) {
+		int nf = (int) toDouble(nfObj);
+		if (nf < 0) {
+			nf = 0;
+		}
+
+		int currentNF = inputFields.size() - 1;
+
+		if (nf < currentNF) {
+			for (int i = currentNF; i > nf; i--) {
+				inputFields.remove(i);
+			}
+		} else if (nf > currentNF) {
+			for (int i = currentNF + 1; i <= nf; i++) {
+				inputFields.add("");
+			}
+		}
+
+		rebuildDollarZeroFromFields();
+	}
+
 	private static int toFieldNumber(Object o) {
 		if (o instanceof Number) {
 			double num = ((Number) o).doubleValue();


### PR DESCRIPTION
## Summary
- update `JRT` with `jrtSetNF` and helper
- call new method from `AVM.assign` when assigning to `NF`
- maintain original `$0` content during field parsing

## Testing
- `mvn test`
- `mvn -DskipTests=false verify`


------
https://chatgpt.com/codex/tasks/task_b_6842bf231d5883218902d156a19b8593