### PR TITLE
Fix regex FS leading/trailing separators

### DIFF
--- a/src/main/java/org/metricshub/jawk/jrt/RegexTokenizer.java
+++ b/src/main/java/org/metricshub/jawk/jrt/RegexTokenizer.java
@@ -23,9 +23,6 @@ package org.metricshub.jawk.jrt;
  */
 
 import java.util.Enumeration;
-import java.util.ArrayList;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 /**
  * Similar to StringTokenizer, except that tokens are delimited
@@ -46,20 +43,7 @@ public class RegexTokenizer implements Enumeration<Object> {
 	 *        within the input string.
 	 */
 	public RegexTokenizer(String input, String delimitterRegexPattern) {
-		ArrayList<String> fields = new ArrayList<>();
-		Pattern pattern = Pattern.compile(delimitterRegexPattern);
-		Matcher matcher = pattern.matcher(input);
-		int last = 0;
-		while (matcher.find()) {
-			if (matcher.start() > last) {
-				fields.add(input.substring(last, matcher.start()));
-			}
-			last = matcher.end();
-		}
-		if (last < input.length()) {
-			fields.add(input.substring(last));
-		}
-		array = fields.toArray(new String[0]);
+		array = input.split(delimitterRegexPattern, -1);
 	}
 
 	/** {@inheritDoc} */

--- a/src/test/java/org/metricshub/jawk/JRTTest.java
+++ b/src/test/java/org/metricshub/jawk/JRTTest.java
@@ -160,8 +160,18 @@ public class JRTTest {
 	public void testSplitRegexWhitespace() {
 		AssocArray aa = new AssocArray(false);
 		int n = JRT.split("[ \t]+", aa, " 9853   shen", "%.6g", Locale.US);
-		assertEquals(2, n);
-		assertEquals("9853", aa.get(1));
-		assertEquals("shen", aa.get(2));
+		assertEquals(3, n);
+		assertEquals("", aa.get(1));
+		assertEquals("9853", aa.get(2));
+		assertEquals("shen", aa.get(3));
+	}
+
+	@Test
+	public void testRegexFsKeepsLeadingAndTrailingSeparators() throws Exception {
+		String result = AwkTestHelper
+				.runAwk(
+						"BEGIN { FS = \"[ \\t\\n]+\" } { print $2 }",
+						"  a  b  c  d ");
+		assertEquals("a\n", result);
 	}
 }


### PR DESCRIPTION
## Summary
- ensure RegexTokenizer preserves empty fields when regex FS matches at start or end
- simplify regex tokenization by delegating to Java's String.split

## Testing
- `mvn formatter:format`
- `mvn license:update-file-header`
- `mvn verify` *(unit tests: 139 run, 0 failures, 2 skipped; compatibility tests: 10 failures, 1 error - ignored)*

------
https://chatgpt.com/codex/tasks/task_b_689342618558832194209fda0b6b2794