### PR TITLE
Refactor JRT input consumption logic

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -2464,8 +2464,17 @@ public class AVM implements AwkInterpreter, VariableManager {
 		return retval;
 	}
 
+	/**
+	 * Consume input from the current source defined in {@link #settings} and push
+	 * the line onto the stack when {@code getline} semantics are required.
+	 *
+	 * @param forGetline {@code true} when called for {@code getline}; otherwise
+	 *        fields are parsed immediately and nothing is pushed
+	 * @return {@code true} if a line of input was read
+	 * @throws IOException if an I/O error occurs while reading input
+	 */
 	private boolean avmConsumeInput(boolean forGetline) throws IOException {
-		boolean retval = jrt.jrtConsumeInput(settings.getInput(), forGetline, locale);
+		boolean retval = jrt.consumeInput(settings.getInput(), forGetline, locale);
 		if (retval && forGetline) {
 			push(jrt.getInputLine());
 		}

--- a/src/test/java/org/metricshub/jawk/JRTConsumeInputTest.java
+++ b/src/test/java/org/metricshub/jawk/JRTConsumeInputTest.java
@@ -1,0 +1,74 @@
+package org.metricshub.jawk;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.Test;
+import org.metricshub.jawk.Awk;
+import org.metricshub.jawk.util.AwkSettings;
+import org.metricshub.jawk.util.ScriptSource;
+
+/**
+ * Tests for the {@link org.metricshub.jawk.jrt.JRT#consumeInput} method.
+ */
+public class JRTConsumeInputTest {
+
+	/**
+	 * Ensures that variable assignments interleaved with filenames in
+	 * {@code ARGV} correctly advance {@code NR}.
+	 *
+	 * @throws Exception if the AWK invocation fails
+	 */
+	@Test
+	public void testVariableAssignmentBetweenFilesIncrementsNR() throws Exception {
+		File file1 = File.createTempFile("jrt", "1");
+		file1.deleteOnExit();
+		Files.write(file1.toPath(), "a\n".getBytes(StandardCharsets.UTF_8));
+
+		File file2 = File.createTempFile("jrt", "2");
+		file2.deleteOnExit();
+		Files.write(file2.toPath(), "b\n".getBytes(StandardCharsets.UTF_8));
+
+		AwkSettings settings = new AwkSettings();
+		settings.setDefaultRS("\n");
+		settings.setDefaultORS("\n");
+		settings.addNameValueOrFileName(file1.getAbsolutePath());
+		settings.addNameValueOrFileName("X=1");
+		settings.addNameValueOrFileName(file2.getAbsolutePath());
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		settings.setOutputStream(new PrintStream(out, true, StandardCharsets.UTF_8.name()));
+		settings.addScriptSource(new ScriptSource("Body", new StringReader("{ next } \nEND { print NR }"), false));
+
+		new Awk().invoke(settings);
+
+		assertEquals("3\n", out.toString("UTF-8"));
+	}
+}


### PR DESCRIPTION
## Summary
- Refactor `JRT` input consumption into smaller helpers and cleaner control flow
- Simplify `ARGC` handling using `toLong` and `Math.toIntExact`
- Add regression test for variable assignments between input files
- Document refactored input processing helpers and runtime hook

## Testing
- `mvn formatter:format`
- `mvn license:update-file-header`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_68ac8ca4439c8321bbf949e863161f55