### PR TITLE
Suppress SpotBugs fallthrough warning in readString

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.9.3.2</version>
+				<version>4.9.4.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
+++ b/src/main/java/org/metricshub/jawk/frontend/AwkParser.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.metricshub.jawk.NotImplementedError;
 import org.metricshub.jawk.backend.AVM;
 import org.metricshub.jawk.ext.JawkExtension;
@@ -400,6 +401,7 @@ public class AwkParser {
 	 *
 	 * @throws IOException
 	 */
+	@SuppressFBWarnings(value = "SF_SWITCH_FALLTHROUGH", justification = "intentional for escape sequence parsing")
 	private void readString() throws IOException {
 		string.setLength(0);
 


### PR DESCRIPTION
## Summary
- Restore original `readString` logic
- Suppress SpotBugs switch fallthrough warning using `@SuppressFBWarnings`

## Testing
- `mvn test`
- `mvn -DskipTests spotbugs:check`


------
https://chatgpt.com/codex/tasks/task_b_68aca86a15d08321b8391efd4b41fa84