### PR TITLE
Switch to Opcode enum for intermediate instructions

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -46,6 +46,7 @@ import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.frontend.AstNode;
 import org.metricshub.jawk.intermediate.Address;
 import org.metricshub.jawk.intermediate.AwkTuples;
+import org.metricshub.jawk.intermediate.Opcode;
 import org.metricshub.jawk.intermediate.PositionTracker;
 import org.metricshub.jawk.intermediate.UninitializedObject;
 import org.metricshub.jawk.jrt.AssocArray;
@@ -352,10 +353,10 @@ public class AVM implements VariableManager {
 		try {
 			while (!position.isEOF()) {
 				// System_out.println("--> "+position);
-				int opcode = position.opcode();
+				Opcode opcode = position.opcode();
 				// switch on OPCODE
 				switch (opcode) {
-				case AwkTuples.PRINT: {
+				case PRINT: {
 					// arg[0] = # of items to print on the stack
 					// stack[0] = item 1
 					// stack[1] = item 2
@@ -365,7 +366,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PRINT_TO_FILE: {
+				case PRINT_TO_FILE: {
 					// arg[0] = # of items to print on the stack
 					// arg[1] = true=append, false=overwrite
 					// stack[0] = output filename
@@ -394,7 +395,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PRINT_TO_PIPE: {
+				case PRINT_TO_PIPE: {
 					// arg[0] = # of items to print on the stack
 					// stack[0] = command to execute
 					// stack[1] = item 1
@@ -407,7 +408,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PRINTF: {
+				case PRINTF: {
 					// arg[0] = # of items to print on the stack (includes format string)
 					// stack[0] = format string
 					// stack[1] = item 1
@@ -417,7 +418,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PRINTF_TO_FILE: {
+				case PRINTF_TO_FILE: {
 					// arg[0] = # of items to print on the stack (includes format string)
 					// arg[1] = true=append, false=overwrite
 					// stack[0] = output filename
@@ -446,7 +447,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PRINTF_TO_PIPE: {
+				case PRINTF_TO_PIPE: {
 					// arg[0] = # of items to print on the stack (includes format string)
 					// stack[0] = command to execute
 					// stack[1] = format string
@@ -459,7 +460,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SPRINTF: {
+				case SPRINTF: {
 					// arg[0] = # of sprintf arguments
 					// stack[0] = arg1 (format string)
 					// stack[1] = arg2
@@ -469,7 +470,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.LENGTH: {
+				case LENGTH: {
 					// arg[0] = 0==use $0, otherwise, use the stack element
 					// stack[0] = element to measure (only if arg[0] != 0)
 
@@ -485,19 +486,19 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PUSH: {
+				case PUSH: {
 					// arg[0] = constant to push onto the stack
 					push(position.arg(0));
 					position.next();
 					break;
 				}
-				case AwkTuples.POP: {
+				case POP: {
 					// stack[0] = item to pop from the stack
 					pop();
 					position.next();
 					break;
 				}
-				case AwkTuples.IFFALSE: {
+				case IFFALSE: {
 					// arg[0] = address to jump to if top of stack is false
 					// stack[0] = item to check
 
@@ -512,7 +513,7 @@ public class AVM implements VariableManager {
 					}
 					break;
 				}
-				case AwkTuples.TO_NUMBER: {
+				case TO_NUMBER: {
 					// stack[0] = item to convert to a number
 
 					// if int, then check for 0
@@ -523,7 +524,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.IFTRUE: {
+				case IFTRUE: {
 					// arg[0] = address to jump to if top of stack is true
 					// stack[0] = item to check
 
@@ -538,7 +539,7 @@ public class AVM implements VariableManager {
 					}
 					break;
 				}
-				case AwkTuples.NOT: {
+				case NOT: {
 					// stack[0] = item to logically negate
 
 					Object o = pop();
@@ -553,7 +554,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.NEGATE: {
+				case NEGATE: {
 					// stack[0] = item to numerically negate
 
 					double d = JRT.toDouble(pop());
@@ -565,7 +566,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.UNARY_PLUS: {
+				case UNARY_PLUS: {
 					// stack[0] = item to convert to a number
 					double d = JRT.toDouble(pop());
 					if (JRT.isActuallyLong(d)) {
@@ -576,18 +577,18 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.GOTO: {
+				case GOTO: {
 					// arg[0] = address
 
 					position.jump(position.addressArg());
 					break;
 				}
-				case AwkTuples.NOP: {
+				case NOP: {
 					// do nothing, just advance the position
 					position.next();
 					break;
 				}
-				case AwkTuples.CONCAT: {
+				case CONCAT: {
 					// stack[0] = string1
 					// stack[1] = string2
 					String convfmt = getCONVFMT().toString();
@@ -598,7 +599,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ASSIGN: {
+				case ASSIGN: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = value
@@ -608,7 +609,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ASSIGN_ARRAY: {
+				case ASSIGN_ARRAY: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = array index
@@ -624,12 +625,12 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PLUS_EQ_ARRAY:
-				case AwkTuples.MINUS_EQ_ARRAY:
-				case AwkTuples.MULT_EQ_ARRAY:
-				case AwkTuples.DIV_EQ_ARRAY:
-				case AwkTuples.MOD_EQ_ARRAY:
-				case AwkTuples.POW_EQ_ARRAY: {
+				case PLUS_EQ_ARRAY:
+				case MINUS_EQ_ARRAY:
+				case MULT_EQ_ARRAY:
+				case DIV_EQ_ARRAY:
+				case MOD_EQ_ARRAY:
+				case POW_EQ_ARRAY: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = array index
@@ -663,22 +664,22 @@ public class AVM implements VariableManager {
 					double newVal;
 
 					switch (opcode) {
-					case AwkTuples.PLUS_EQ_ARRAY:
+					case PLUS_EQ_ARRAY:
 						newVal = origVal + val;
 						break;
-					case AwkTuples.MINUS_EQ_ARRAY:
+					case MINUS_EQ_ARRAY:
 						newVal = origVal - val;
 						break;
-					case AwkTuples.MULT_EQ_ARRAY:
+					case MULT_EQ_ARRAY:
 						newVal = origVal * val;
 						break;
-					case AwkTuples.DIV_EQ_ARRAY:
+					case DIV_EQ_ARRAY:
 						newVal = origVal / val;
 						break;
-					case AwkTuples.MOD_EQ_ARRAY:
+					case MOD_EQ_ARRAY:
 						newVal = origVal % val;
 						break;
-					case AwkTuples.POW_EQ_ARRAY:
+					case POW_EQ_ARRAY:
 						newVal = Math.pow(origVal, val);
 						break;
 					default:
@@ -694,7 +695,7 @@ public class AVM implements VariableManager {
 					break;
 				}
 
-				case AwkTuples.ASSIGN_AS_INPUT: {
+				case ASSIGN_AS_INPUT: {
 					// stack[0] = value
 					jrt.setInputLine(pop().toString());
 					jrt.jrtParseFields();
@@ -703,7 +704,7 @@ public class AVM implements VariableManager {
 					break;
 				}
 
-				case AwkTuples.ASSIGN_AS_INPUT_FIELD: {
+				case ASSIGN_AS_INPUT_FIELD: {
 					// stack[0] = field number
 					// stack[1] = value
 					Object fieldNumObj = pop();
@@ -728,12 +729,12 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PLUS_EQ:
-				case AwkTuples.MINUS_EQ:
-				case AwkTuples.MULT_EQ:
-				case AwkTuples.DIV_EQ:
-				case AwkTuples.MOD_EQ:
-				case AwkTuples.POW_EQ: {
+				case PLUS_EQ:
+				case MINUS_EQ:
+				case MULT_EQ:
+				case DIV_EQ:
+				case MOD_EQ:
+				case POW_EQ: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = value
@@ -747,22 +748,22 @@ public class AVM implements VariableManager {
 					double d2 = JRT.toDouble(o2);
 					double ans;
 					switch (opcode) {
-					case AwkTuples.PLUS_EQ:
+					case PLUS_EQ:
 						ans = d1 + d2;
 						break;
-					case AwkTuples.MINUS_EQ:
+					case MINUS_EQ:
 						ans = d1 - d2;
 						break;
-					case AwkTuples.MULT_EQ:
+					case MULT_EQ:
 						ans = d1 * d2;
 						break;
-					case AwkTuples.DIV_EQ:
+					case DIV_EQ:
 						ans = d1 / d2;
 						break;
-					case AwkTuples.MOD_EQ:
+					case MOD_EQ:
 						ans = d1 % d2;
 						break;
-					case AwkTuples.POW_EQ:
+					case POW_EQ:
 						ans = Math.pow(d1, d2);
 						break;
 					default:
@@ -779,12 +780,12 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.PLUS_EQ_INPUT_FIELD:
-				case AwkTuples.MINUS_EQ_INPUT_FIELD:
-				case AwkTuples.MULT_EQ_INPUT_FIELD:
-				case AwkTuples.DIV_EQ_INPUT_FIELD:
-				case AwkTuples.MOD_EQ_INPUT_FIELD:
-				case AwkTuples.POW_EQ_INPUT_FIELD: {
+				case PLUS_EQ_INPUT_FIELD:
+				case MINUS_EQ_INPUT_FIELD:
+				case MULT_EQ_INPUT_FIELD:
+				case DIV_EQ_INPUT_FIELD:
+				case MOD_EQ_INPUT_FIELD:
+				case POW_EQ_INPUT_FIELD: {
 					// stack[0] = dollar_fieldNumber
 					// stack[1] = inc value
 
@@ -796,22 +797,22 @@ public class AVM implements VariableManager {
 					Object numObj = jrt.jrtGetInputField(fieldnum);
 					double num;
 					switch (opcode) {
-					case AwkTuples.PLUS_EQ_INPUT_FIELD:
+					case PLUS_EQ_INPUT_FIELD:
 						num = JRT.toDouble(numObj) + incval;
 						break;
-					case AwkTuples.MINUS_EQ_INPUT_FIELD:
+					case MINUS_EQ_INPUT_FIELD:
 						num = JRT.toDouble(numObj) - incval;
 						break;
-					case AwkTuples.MULT_EQ_INPUT_FIELD:
+					case MULT_EQ_INPUT_FIELD:
 						num = JRT.toDouble(numObj) * incval;
 						break;
-					case AwkTuples.DIV_EQ_INPUT_FIELD:
+					case DIV_EQ_INPUT_FIELD:
 						num = JRT.toDouble(numObj) / incval;
 						break;
-					case AwkTuples.MOD_EQ_INPUT_FIELD:
+					case MOD_EQ_INPUT_FIELD:
 						num = JRT.toDouble(numObj) % incval;
 						break;
-					case AwkTuples.POW_EQ_INPUT_FIELD:
+					case POW_EQ_INPUT_FIELD:
 						num = Math.pow(JRT.toDouble(numObj), incval);
 						break;
 					default:
@@ -825,21 +826,21 @@ public class AVM implements VariableManager {
 
 					break;
 				}
-				case AwkTuples.INC: {
+				case INC: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					inc(position.intArg(0), position.boolArg(1));
 					position.next();
 					break;
 				}
-				case AwkTuples.DEC: {
+				case DEC: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					dec(position.intArg(0), position.boolArg(1));
 					position.next();
 					break;
 				}
-				case AwkTuples.POSTINC: {
+				case POSTINC: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					pop();
@@ -847,7 +848,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.POSTDEC: {
+				case POSTDEC: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					pop();
@@ -855,7 +856,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.INC_ARRAY_REF: {
+				case INC_ARRAY_REF: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = array index
@@ -878,7 +879,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DEC_ARRAY_REF: {
+				case DEC_ARRAY_REF: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = array index
@@ -901,7 +902,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.INC_DOLLAR_REF: {
+				case INC_DOLLAR_REF: {
 					// stack[0] = dollar index (field number)
 					int fieldnum = parseIntField(pop(), position);
 
@@ -919,7 +920,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DEC_DOLLAR_REF: {
+				case DEC_DOLLAR_REF: {
 					// stack[0] = dollar index (field number)
 					// same code as GET_INPUT_FIELD:
 					int fieldnum = parseIntField(pop(), position);
@@ -938,7 +939,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DEREFERENCE: {
+				case DEREFERENCE: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					boolean isGlobal = position.boolArg(2);
@@ -956,7 +957,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DEREF_ARRAY: {
+				case DEREF_ARRAY: {
 					// stack[0] = array index
 					// stack[1] = AssocArray
 					Object idx = pop(); // idx
@@ -970,7 +971,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SRAND: {
+				case SRAND: {
 					// arg[0] = numArgs (where 0 = no args, anything else = one argument)
 					// stack[0] = seed (only if numArgs != 0)
 					long numArgs = position.intArg(0);
@@ -1000,49 +1001,49 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.RAND: {
+				case RAND: {
 					push(randomNumberGenerator.nextDouble());
 					position.next();
 					break;
 				}
-				case AwkTuples.INTFUNC:
-				case AwkTuples.CAST_INT: {
+				case INTFUNC:
+				case CAST_INT: {
 					// stack[0] = arg to int() function
 					push((long) JRT.toDouble(pop()));
 					position.next();
 					break;
 				}
-				case AwkTuples.SQRT: {
+				case SQRT: {
 					// stack[0] = arg to sqrt() function
 					push(Math.sqrt(JRT.toDouble(pop())));
 					position.next();
 					break;
 				}
-				case AwkTuples.LOG: {
+				case LOG: {
 					// stack[0] = arg to log() function
 					push(Math.log(JRT.toDouble(pop())));
 					position.next();
 					break;
 				}
-				case AwkTuples.EXP: {
+				case EXP: {
 					// stack[0] = arg to exp() function
 					push(Math.exp(JRT.toDouble(pop())));
 					position.next();
 					break;
 				}
-				case AwkTuples.SIN: {
+				case SIN: {
 					// stack[0] = arg to sin() function
 					push(Math.sin(JRT.toDouble(pop())));
 					position.next();
 					break;
 				}
-				case AwkTuples.COS: {
+				case COS: {
 					// stack[0] = arg to cos() function
 					push(Math.cos(JRT.toDouble(pop())));
 					position.next();
 					break;
 				}
-				case AwkTuples.ATAN2: {
+				case ATAN2: {
 					// stack[0] = 2nd arg to atan2() function
 					// stack[1] = 1st arg to atan2() function
 					double d2 = JRT.toDouble(pop());
@@ -1051,7 +1052,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.MATCH: {
+				case MATCH: {
 					// stack[0] = 2nd arg to match() function
 					// stack[1] = 1st arg to match() function
 					String convfmt = getCONVFMT().toString();
@@ -1087,7 +1088,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.INDEX: {
+				case INDEX: {
 					// stack[0] = 2nd arg to index() function
 					// stack[1] = 1st arg to index() function
 					String convfmt = getCONVFMT().toString();
@@ -1097,7 +1098,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUB_FOR_DOLLAR_0: {
+				case SUB_FOR_DOLLAR_0: {
 					// arg[0] = isGlobal
 					// stack[0] = replacement string
 					// stack[1] = ere
@@ -1118,7 +1119,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUB_FOR_DOLLAR_REFERENCE: {
+				case SUB_FOR_DOLLAR_REFERENCE: {
 					// arg[0] = isGlobal
 					// stack[0] = field num
 					// stack[1] = original field value
@@ -1146,7 +1147,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUB_FOR_VARIABLE: {
+				case SUB_FOR_VARIABLE: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// arg[2] = isGsub
@@ -1162,7 +1163,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUB_FOR_ARRAY_REFERENCE: {
+				case SUB_FOR_ARRAY_REFERENCE: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// arg[2] = isGsub
@@ -1181,7 +1182,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SPLIT: {
+				case SPLIT: {
 					// arg[0] = num args
 					// stack[0] = field_sep (only if num args == 3)
 					// stack[1] = array
@@ -1222,7 +1223,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUBSTR: {
+				case SUBSTR: {
 					// arg[0] = num args
 					// stack[0] = length (only if num args == 3)
 					// stack[1] = start pos
@@ -1256,33 +1257,33 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.TOLOWER: {
+				case TOLOWER: {
 					// stack[0] = string
 					push(JRT.toAwkString(pop(), getCONVFMT().toString(), locale).toLowerCase());
 					position.next();
 					break;
 				}
-				case AwkTuples.TOUPPER: {
+				case TOUPPER: {
 					// stack[0] = string
 					push(JRT.toAwkString(pop(), getCONVFMT().toString(), locale).toUpperCase());
 					position.next();
 					break;
 				}
-				case AwkTuples.SYSTEM: {
+				case SYSTEM: {
 					// stack[0] = command string
 					String s = JRT.toAwkString(pop(), getCONVFMT().toString(), locale);
 					push(jrt.jrtSystem(s));
 					position.next();
 					break;
 				}
-				case AwkTuples.SWAP: {
+				case SWAP: {
 					// stack[0] = item1
 					// stack[1] = item2
 					swapOnStack();
 					position.next();
 					break;
 				}
-				case AwkTuples.CMP_EQ: {
+				case CMP_EQ: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1291,7 +1292,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CMP_LT: {
+				case CMP_LT: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1300,7 +1301,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CMP_GT: {
+				case CMP_GT: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1309,7 +1310,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.MATCHES: {
+				case MATCHES: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1332,7 +1333,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SLEEP: {
+				case SLEEP: {
 					// arg[0] = numArgs
 					// if (numArgs==1)
 					// stack[0] = # of seconds
@@ -1356,7 +1357,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DUMP: {
+				case DUMP: {
 					// arg[0] = numArgs
 					// if (numArgs==0)
 					// all Jawk global variables
@@ -1377,7 +1378,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ADD: {
+				case ADD: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1393,7 +1394,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUBTRACT: {
+				case SUBTRACT: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1409,7 +1410,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.MULTIPLY: {
+				case MULTIPLY: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1425,7 +1426,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DIVIDE: {
+				case DIVIDE: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1441,7 +1442,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.MOD: {
+				case MOD: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1457,7 +1458,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.POW: {
+				case POW: {
 					// stack[0] = item2
 					// stack[1] = item1
 					Object o2 = pop();
@@ -1473,7 +1474,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DUP: {
+				case DUP: {
 					// stack[0] = top of stack item
 					Object o = pop();
 					push(o);
@@ -1481,7 +1482,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.KEYLIST: {
+				case KEYLIST: {
 					// stack[0] = AssocArray
 					Object o = pop();
 					assert o != null;
@@ -1495,7 +1496,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.IS_EMPTY_KEYLIST: {
+				case IS_EMPTY_KEYLIST: {
 					// arg[0] = address
 					// stack[0] = Deque
 					Object o = pop();
@@ -1512,7 +1513,7 @@ public class AVM implements VariableManager {
 					}
 					break;
 				}
-				case AwkTuples.GET_FIRST_AND_REMOVE_FROM_KEYLIST: {
+				case GET_FIRST_AND_REMOVE_FROM_KEYLIST: {
 					// stack[0] = Deque
 					Object o = pop();
 					if (o == null || !(o instanceof Deque)) {
@@ -1527,7 +1528,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CHECK_CLASS: {
+				case CHECK_CLASS: {
 					// arg[0] = class object
 					// stack[0] = item to check
 					Object o = pop();
@@ -1540,7 +1541,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CONSUME_INPUT: {
+				case CONSUME_INPUT: {
 					// arg[0] = address
 					// false = do NOT put result on stack...
 					// instead, put it in field vars ($0, $1, ...)
@@ -1552,32 +1553,32 @@ public class AVM implements VariableManager {
 					break;
 				}
 
-				case AwkTuples.SET_INPUT_FOR_EVAL: {
+				case SET_INPUT_FOR_EVAL: {
 					jrt.setInputLineforEval(settings.getInput());
 					position.next();
 					break;
 				}
 
-				case AwkTuples.GETLINE_INPUT: {
+				case GETLINE_INPUT: {
 					avmConsumeInputForGetline();
 					position.next();
 					break;
 				}
-				case AwkTuples.USE_AS_FILE_INPUT: {
+				case USE_AS_FILE_INPUT: {
 					// stack[0] = filename
 					String s = JRT.toAwkString(pop(), getCONVFMT().toString(), locale);
 					avmConsumeFileInputForGetline(s);
 					position.next();
 					break;
 				}
-				case AwkTuples.USE_AS_COMMAND_INPUT: {
+				case USE_AS_COMMAND_INPUT: {
 					// stack[0] = command line
 					String s = JRT.toAwkString(pop(), getCONVFMT().toString(), locale);
 					avmConsumeCommandInputForGetline(s);
 					position.next();
 					break;
 				}
-				case AwkTuples.NF_OFFSET: {
+				case NF_OFFSET: {
 					// stack[0] = offset
 					nfOffset = position.intArg(0);
 					assert nfOffset != NULL_OFFSET;
@@ -1586,7 +1587,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.NR_OFFSET: {
+				case NR_OFFSET: {
 					// stack[0] = offset
 					nrOffset = position.intArg(0);
 					assert nrOffset != NULL_OFFSET;
@@ -1595,7 +1596,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.FNR_OFFSET: {
+				case FNR_OFFSET: {
 					// stack[0] = offset
 					fnrOffset = position.intArg(0);
 					assert fnrOffset != NULL_OFFSET;
@@ -1604,7 +1605,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.FS_OFFSET: {
+				case FS_OFFSET: {
 					// stack[0] = offset
 					fsOffset = position.intArg(0);
 					assert fsOffset != NULL_OFFSET;
@@ -1617,7 +1618,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.RS_OFFSET: {
+				case RS_OFFSET: {
 					// stack[0] = offset
 					rsOffset = position.intArg(0);
 					assert rsOffset != NULL_OFFSET;
@@ -1626,7 +1627,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.OFS_OFFSET: {
+				case OFS_OFFSET: {
 					// stack[0] = offset
 					ofsOffset = position.intArg(0);
 					assert ofsOffset != NULL_OFFSET;
@@ -1635,7 +1636,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ORS_OFFSET: {
+				case ORS_OFFSET: {
 					// stack[0] = offset
 					orsOffset = position.intArg(0);
 					assert orsOffset != NULL_OFFSET;
@@ -1644,7 +1645,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.RSTART_OFFSET: {
+				case RSTART_OFFSET: {
 					// stack[0] = offset
 					rstartOffset = position.intArg(0);
 					assert rstartOffset != NULL_OFFSET;
@@ -1653,7 +1654,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.RLENGTH_OFFSET: {
+				case RLENGTH_OFFSET: {
 					// stack[0] = offset
 					rlengthOffset = position.intArg(0);
 					assert rlengthOffset != NULL_OFFSET;
@@ -1662,7 +1663,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.FILENAME_OFFSET: {
+				case FILENAME_OFFSET: {
 					// stack[0] = offset
 					filenameOffset = position.intArg(0);
 					assert filenameOffset != NULL_OFFSET;
@@ -1671,7 +1672,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SUBSEP_OFFSET: {
+				case SUBSEP_OFFSET: {
 					// stack[0] = offset
 					subsepOffset = position.intArg(0);
 					assert subsepOffset != NULL_OFFSET;
@@ -1680,7 +1681,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CONVFMT_OFFSET: {
+				case CONVFMT_OFFSET: {
 					// stack[0] = offset
 					convfmtOffset = position.intArg(0);
 					assert convfmtOffset != NULL_OFFSET;
@@ -1689,7 +1690,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.OFMT_OFFSET: {
+				case OFMT_OFFSET: {
 					// stack[0] = offset
 					ofmtOffset = position.intArg(0);
 					assert ofmtOffset != NULL_OFFSET;
@@ -1698,7 +1699,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ENVIRON_OFFSET: {
+				case ENVIRON_OFFSET: {
 					// stack[0] = offset
 					//// assignArray(offset, arrIdx, newstring, isGlobal);
 					environOffset = position.intArg(0);
@@ -1712,7 +1713,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ARGC_OFFSET: {
+				case ARGC_OFFSET: {
 					// stack[0] = offset
 					argcOffset = position.intArg(0);
 					assert argcOffset != NULL_OFFSET;
@@ -1723,7 +1724,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.ARGV_OFFSET: {
+				case ARGV_OFFSET: {
 					// stack[0] = offset
 					argvOffset = position.intArg(0);
 					assert argvOffset != NULL_OFFSET;
@@ -1739,14 +1740,14 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.GET_INPUT_FIELD: {
+				case GET_INPUT_FIELD: {
 					// stack[0] = field number
 					int fieldnum = parseIntField(pop(), position);
 					push(jrt.jrtGetInputField(fieldnum));
 					position.next();
 					break;
 				}
-				case AwkTuples.APPLY_RS: {
+				case APPLY_RS: {
 					assert rsOffset != NULL_OFFSET;
 					Object rsObj = runtimeStack.getVariable(rsOffset, true); // true = global
 					if (jrt.getPartitioningReader() != null) {
@@ -1755,7 +1756,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CALL_FUNCTION: {
+				case CALL_FUNCTION: {
 					// arg[0] = function address
 					// arg[1] = function name
 					// arg[2] = # of formal parameters
@@ -1779,7 +1780,7 @@ public class AVM implements VariableManager {
 					// position.next();
 					break;
 				}
-				case AwkTuples.FUNCTION: {
+				case FUNCTION: {
 					// important for compilation,
 					// not needed for interpretation
 					// arg[0] = function name
@@ -1787,19 +1788,19 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SET_RETURN_RESULT: {
+				case SET_RETURN_RESULT: {
 					// stack[0] = return result
 					runtimeStack.setReturnValue(pop());
 					position.next();
 					break;
 				}
-				case AwkTuples.RETURN_FROM_FUNCTION: {
+				case RETURN_FROM_FUNCTION: {
 					position.jump(runtimeStack.popFrame());
 					push(runtimeStack.getReturnValue());
 					position.next();
 					break;
 				}
-				case AwkTuples.SET_NUM_GLOBALS: {
+				case SET_NUM_GLOBALS: {
 					// arg[0] = # of globals
 					assert position.intArg(0) == globalVariableOffsets.size();
 					runtimeStack.setNumGlobals(position.intArg(0));
@@ -1829,14 +1830,14 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CLOSE: {
+				case CLOSE: {
 					// stack[0] = file or command line to close
 					String s = JRT.toAwkString(pop(), getCONVFMT().toString(), locale);
 					push(jrt.jrtClose(s));
 					position.next();
 					break;
 				}
-				case AwkTuples.APPLY_SUBSEP: {
+				case APPLY_SUBSEP: {
 					// arg[0] = # of elements for SUBSEP application
 					// stack[0] = first element
 					// stack[1] = second element
@@ -1860,7 +1861,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DELETE_ARRAY_ELEMENT: {
+				case DELETE_ARRAY_ELEMENT: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// stack[0] = array index
@@ -1874,7 +1875,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.DELETE_ARRAY: {
+				case DELETE_ARRAY: {
 					// arg[0] = offset
 					// arg[1] = isGlobal
 					// (nothing on the stack)
@@ -1884,21 +1885,21 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.SET_EXIT_ADDRESS: {
+				case SET_EXIT_ADDRESS: {
 					// arg[0] = exit address
 					exitAddress = position.addressArg();
 					position.next();
 					break;
 				}
-				case AwkTuples.SET_WITHIN_END_BLOCKS: {
+				case SET_WITHIN_END_BLOCKS: {
 					// arg[0] = whether within the END blocks section
 					withinEndBlocks = position.boolArg(0);
 					position.next();
 					break;
 				}
-				case AwkTuples.EXIT_WITHOUT_CODE:
-				case AwkTuples.EXIT_WITH_CODE: {
-					if (opcode == AwkTuples.EXIT_WITH_CODE) {
+				case EXIT_WITHOUT_CODE:
+				case EXIT_WITH_CODE: {
+					if (opcode == Opcode.EXIT_WITH_CODE) {
 						// stack[0] = exit code
 						exitCode = (int) JRT.toDouble(pop());
 					}
@@ -1921,7 +1922,7 @@ public class AVM implements VariableManager {
 					}
 					break;
 				}
-				case AwkTuples.REGEXP: {
+				case REGEXP: {
 					// arg[0] = string representation of regexp
 					String key = JRT.toAwkString(position.arg(0), getCONVFMT().toString(), locale);
 					Pattern pattern = regexps.get(key);
@@ -1933,7 +1934,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CONDITION_PAIR: {
+				case CONDITION_PAIR: {
 					// stack[0] = End condition
 					// stack[1] = Start condition
 					ConditionPair cp = conditionPairs.get(position.current());
@@ -1947,7 +1948,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.IS_IN: {
+				case IS_IN: {
 					// stack[0] = AssocArray
 					// stack[1] = key to check
 					Object arr = pop();
@@ -1958,17 +1959,17 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.CAST_DOUBLE: {
+				case CAST_DOUBLE: {
 					push(JRT.toDouble(pop()));
 					position.next();
 					break;
 				}
-				case AwkTuples.CAST_STRING: {
+				case CAST_STRING: {
 					push(pop().toString());
 					position.next();
 					break;
 				}
-				case AwkTuples.THIS: {
+				case THIS: {
 					// this is in preparation for a function
 					// call for the JVM-COMPILED script, only
 					// therefore, do NOTHING for the interpreted
@@ -1976,7 +1977,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.EXEC: {
+				case EXEC: {
 					// stack[0] = Jawk code
 
 					// Experimental feature. Use with caution.
@@ -2018,7 +2019,7 @@ public class AVM implements VariableManager {
 					position.next();
 					break;
 				}
-				case AwkTuples.EXTENSION: {
+				case EXTENSION: {
 					// arg[0] = extension keyword
 					// arg[1] = # of args on the stack
 					// arg[2] = true if parent is NOT an extension function call
@@ -2074,7 +2075,7 @@ public class AVM implements VariableManager {
 					break;
 				}
 				default:
-					throw new Error("invalid opcode: " + AwkTuples.toOpcodeString(position.opcode()));
+					throw new Error("invalid opcode: " + position.opcode());
 				}
 			}
 

--- a/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/AwkTuples.java
@@ -24,8 +24,6 @@ package org.metricshub.jawk.intermediate;
 
 import java.io.PrintStream;
 import java.io.Serializable;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,8 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.Deque;
-import org.metricshub.jawk.util.AwkLogger;
-import org.slf4j.Logger;
 
 /**
  * <p>
@@ -49,9 +45,6 @@ public class AwkTuples implements Serializable {
 
 	private static final long serialVersionUID = 2L;
 
-	/** Our logger */
-	private static final Logger LOGGER = AwkLogger.getLogger(AwkTuples.class);
-
 	/** Version Manager */
 	private VersionManager versionManager = new VersionManager();
 
@@ -62,1254 +55,6 @@ public class AwkTuples implements Serializable {
 
 	// made public to be accessable via Java Reflection
 	// (see toOpcodeString() method below)
-	// CHECKSTYLE:OFF
-
-	/**
-	 * Pops an item off the operand stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int POP = 257; // x -> 0
-	/**
-	 * Pushes an item onto the operand stack.
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int PUSH = 258; // 0 -> x
-	/**
-	 * Pops and evaluates the top-of-stack; if
-	 * false, it jumps to a specified address.
-	 * <p>
-	 * Argument: address
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int IFFALSE = 259; // x -> 0
-	/**
-	 * Converts the top-of-stack to a number.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x (as a number)
-	 */
-	public static final int TO_NUMBER = 260; // x1 -> x2
-	/**
-	 * Pops and evaluates the top-of-stack; if
-	 * true, it jumps to a specified address.
-	 * <p>
-	 * Argument: address
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int IFTRUE = 261; // x -> 0
-	/**
-	 * Jumps to a specified address. The operand stack contents
-	 * are unaffected.
-	 */
-	public static final int GOTO = 262; // 0 -> 0
-	/**
-	 * A no-operation. The operand stack contents are
-	 * unaffected.
-	 */
-	public static final int NOP = 263; // 0 -> 0
-	/**
-	 * Prints N number of items that are on the operand stack.
-	 * The number of items are passed in as a tuple argument.
-	 * <p>
-	 * Argument: # of items (N)
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINT = 264; // x1, x2, ... xn -> 0
-	/**
-	 * Prints N number of items that are on the operand stack to
-	 * a specified file. The file is passed in on the stack.
-	 * The number of items are passed in as a tuple argument,
-	 * as well as whether to overwrite the file or not (append mode).
-	 * <p>
-	 * Argument 1: # of items (N)<br/>
-	 * Argument 2: true = append, false = overwrite
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN filename ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINT_TO_FILE = 265; // x1, x2, ... xn -> 0
-	/**
-	 * Prints N number of items that are on the operand stack to
-	 * a process executing a specified command (via a pipe).
-	 * The command string is passed in on the stack.
-	 * The number of items are passed in as a tuple argument.
-	 * <p>
-	 * Argument: # of items (N)
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN command-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINT_TO_PIPE = 266; // x1, x2, ... xn -> 0
-	/**
-	 * Performs a formatted print of N items that are on the operand stack.
-	 * The number of items are passed in as a tuple argument.
-	 * <p>
-	 * Argument: # of items (N)
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINTF = 267; // x1, x2, ... xn -> 0
-	/**
-	 * Performs a formatted print of N items that are on the operand stack to
-	 * a specified file. The file is passed in on the stack.
-	 * The number of items are passed in as a tuple argument,
-	 * as well as whether to overwrite the file or not (append mode).
-	 * <p>
-	 * Argument 1: # of items (N)<br/>
-	 * Argument 2: true = append, false = overwrite
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN filename ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINTF_TO_FILE = 268; // x1, x2, ... xn -> 0
-	/**
-	 * Performs a formatted print of N items that are on the operand stack to
-	 * a process executing a specified command (via a pipe).
-	 * The command string is passed in on the stack.
-	 * The number of items are passed in as a tuple argument.
-	 * <p>
-	 * Argument: # of items (N)
-	 * <p>
-	 * Stack before: x1 x2 x3 .. xN command-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int PRINTF_TO_PIPE = 269; // x1, x2, ... xn -> 0
-	/** Constant <code>SPRINTF=270</code> */
-	public static final int SPRINTF = 270; // x1, x2, ... xn -> 0
-	/**
-	 * Depending on the argument, pop and evaluate the string length of the top-of-stack
-	 * or evaluate the string length of $0; in either case, push the result onto
-	 * the stack.
-	 * <p>
-	 * The input field length evaluation mode is provided to support backward
-	 * compatibility with the deprecated usage of length (i.e., no arguments).
-	 * <p>
-	 * Argument: 0 to use $0, use top-of-stack otherwise
-	 * <p>
-	 * If argument is 0:
-	 * <blockquote>
-	 * Stack before: ...<br/>
-	 * Stack after: length-of-$0 ...
-	 * </blockquote>
-	 * else
-	 * <blockquote>
-	 * Stack before: x ...<br/>
-	 * Stack after: length-of-x ...
-	 * </blockquote>
-	 */
-	public static final int LENGTH = 271; // 0 -> x or x1 -> x2
-	/**
-	 * Pop and concatenate two strings from the top-of-stack; push the result onto
-	 * the stack.
-	 * <p>
-	 * Stack before: x y ...<br/>
-	 * Stack after: x-concatenated-with-y ...
-	 */
-	public static final int CONCAT = 272; // x2, x1 -> x1x2
-	/**
-	 * Assigns the top-of-stack to a variable. The contents of the stack
-	 * are unaffected.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int ASSIGN = 273; // x -> 0
-	/**
-	 * Assigns an item to an array element. The item remains on the stack.
-	 * <p>
-	 * Argument 1: offset of the particular associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: index-into-array item ...<br/>
-	 * Stack after: item ...
-	 */
-	public static final int ASSIGN_ARRAY = 274; // x2, x1 -> 0
-	/**
-	 * Assigns the top-of-stack to $0. The contents of the stack are unaffected.
-	 * Upon assignment, individual field variables are recalculated.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int ASSIGN_AS_INPUT = 275; // x -> 0
-	/**
-	 * Assigns an item as a particular input field; the field number can be 0.
-	 * Upon assignment, associating input fields are affected. For example, if
-	 * the following assignment were made:
-	 * <blockquote>
-	 *
-	 * <pre>
-	 * $3 = "hi"
-	 * </pre>
-	 *
-	 * </blockquote>
-	 * $0 would be recalculated. Likewise, if the following assignment were made:
-	 * <blockquote>
-	 *
-	 * <pre>
-	 * $0 = "hello there"
-	 * </pre>
-	 *
-	 * </blockquote>
-	 * $1, $2, ... would be recalculated.
-	 * <p>
-	 * Stack before: field-num x ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int ASSIGN_AS_INPUT_FIELD = 276; // x, y -> x
-	/**
-	 * Obtains an item from the variable manager and push it onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int DEREFERENCE = 277; // 0 -> x
-	/**
-	 * Increase the contents of the variable by an adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x+n ...
-	 */
-	public static final int PLUS_EQ = 278; // x -> x
-	/**
-	 * Decreases the contents of the variable by an adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x-n ...
-	 */
-	public static final int MINUS_EQ = 279; // x -> x
-	/**
-	 * Multiplies the contents of the variable by an adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x*n ...
-	 */
-	public static final int MULT_EQ = 280; // x -> x
-	/**
-	 * Divides the contents of the variable by an adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x/n ...
-	 */
-	public static final int DIV_EQ = 281; // x -> x
-	/**
-	 * Takes the modules of the contents of the variable by an adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x%n ...
-	 */
-	public static final int MOD_EQ = 282; // x -> x
-	/**
-	 * Raises the contents of the variable to the power of the adjustment value;
-	 * assigns the result to the variable and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: n ...<br/>
-	 * Stack after: x^n ...
-	 */
-	public static final int POW_EQ = 283; // x -> x
-	/**
-	 * Increase the contents of an indexed array by an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x+n ...
-	 */
-	public static final int PLUS_EQ_ARRAY = 284; // x -> x
-	/**
-	 * Decreases the contents of an indexed array by an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x-n ...
-	 */
-	public static final int MINUS_EQ_ARRAY = 285; // x -> x
-	/**
-	 * Multiplies the contents of an indexed array by an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x*n ...
-	 */
-	public static final int MULT_EQ_ARRAY = 286; // x -> x
-	/**
-	 * Divides the contents of an indexed array by an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x/n ...
-	 */
-	public static final int DIV_EQ_ARRAY = 287; // x -> x
-	/**
-	 * Takes the modulus of the contents of an indexed array by an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x%n ...
-	 */
-	public static final int MOD_EQ_ARRAY = 288; // x -> x
-	/**
-	 * Raises the contents of an indexed array to the power of an adjustment value;
-	 * assigns the result to the array and pushes the result onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx n ...<br/>
-	 * Stack after: x^n ...
-	 */
-	public static final int POW_EQ_ARRAY = 289; // x -> x
-	/**
-	 * Increases the contents of an input field by an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x+n ...
-	 */
-	public static final int PLUS_EQ_INPUT_FIELD = 290; // x1,x2 -> x
-	/**
-	 * Decreases the contents of an input field by an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x-n ...
-	 */
-	public static final int MINUS_EQ_INPUT_FIELD = 291; // x1,x2 -> x
-	/**
-	 * Multiplies the contents of an input field by an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x*n ...
-	 */
-	public static final int MULT_EQ_INPUT_FIELD = 292; // x1,x2 -> x
-	/**
-	 * Divides the contents of an input field by an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x/n ...
-	 */
-	public static final int DIV_EQ_INPUT_FIELD = 293; // x1,x2 -> x
-	/**
-	 * Takes the modulus of the contents of an input field by an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x%n ...
-	 */
-	public static final int MOD_EQ_INPUT_FIELD = 294; // x1,x2 -> x
-	/**
-	 * Raises the contents of an input field to the power of an adjustment value;
-	 * assigns the result to the input field and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: input-field_number n ...<br/>
-	 * Stack after: x^n ...
-	 */
-	public static final int POW_EQ_INPUT_FIELD = 295; // x1,x2 -> x
-
-	/**
-	 * Seeds the random number generator. If there are no arguments, the current
-	 * time (as a long value) is used as the seed. Otherwise, the top-of-stack is
-	 * popped and used as the seed value.
-	 * <p>
-	 * Argument: # of arguments
-	 * <p>
-	 * If # of arguments is 0:
-	 * <blockquote>
-	 * Stack before: ...<br/>
-	 * Stack after: old-seed ...
-	 * </blockquote>
-	 * else
-	 * <blockquote>
-	 * Stack before: x ...<br/>
-	 * Stack after: old-seed ...
-	 * </blockquote>
-	 */
-	public static final int SRAND = 296; // x2, x1 -> x1, x2
-	/**
-	 * Obtains the next random number from the random number generator
-	 * and push it onto the stack.
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: random-number ...
-	 */
-	public static final int RAND = 297; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, removes its fractional part,
-	 * if any, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: (int)x ...
-	 */
-	public static final int INTFUNC = 298; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, takes its square root,
-	 * and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: sqrt(x) ...
-	 */
-	public static final int SQRT = 299; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, calls the java.lang.Math.log method
-	 * with the top-of-stack as the argument, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: log(x) ...
-	 */
-	public static final int LOG = 300; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, calls the java.lang.Math.exp method
-	 * with the top-of-stack as the argument, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: exp(x) ...
-	 */
-	public static final int EXP = 301; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, calls the java.lang.Math.sin method
-	 * with the top-of-stack as the argument, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: sin(x) ...
-	 */
-	public static final int SIN = 302; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the top-of-stack, calls the java.lang.Math.cos method
-	 * with the top-of-stack as the argument, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: cos(x) ...
-	 */
-	public static final int COS = 303; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that pops the first two items off the stack,
-	 * calls the java.lang.Math.atan2 method
-	 * with these as arguments, and places the result onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: atan2(x1,x2) ...
-	 */
-	public static final int ATAN2 = 304; // x2, x1 -> x1, x2
-	/**
-	 * Built-in function that searches a string as input to a regular expression,
-	 * the location of the match is pushed onto the stack.
-	 * The RSTART and RLENGTH variables are set as a side effect.
-	 * If a match is found, RSTART and function return value are set
-	 * to the location of the match and RLENGTH is set to the length
-	 * of the substring matched against the regular expression.
-	 * If no match is found, RSTART (and return value) is set to
-	 * 0 and RLENGTH is set to -1.
-	 * <p>
-	 * Stack before: string regexp ...<br/>
-	 * Stack after: RSTART ...
-	 */
-	public static final int MATCH = 305; // x1, x2 -> x
-	/**
-	 * Built-in function that locates a substring within a source string
-	 * and pushes the location onto the stack. If the substring is
-	 * not found, 0 is pushed onto the stack.
-	 * <p>
-	 * Stack before: string substring ...<br/>
-	 * Stack after: location-index ...
-	 */
-	public static final int INDEX = 306; // x1, x2 -> x
-	/**
-	 * Built-in function that substitutes an occurrence (or all occurrences)
-	 * of a string in $0 and replaces it with another.
-	 * <p>
-	 * Argument: true if global sub, false otherwise.
-	 * <p>
-	 * Stack before: regexp replacement-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SUB_FOR_DOLLAR_0 = 307; // x -> 0
-	/**
-	 * Built-in function that substitutes an occurrence (or all occurrences)
-	 * of a string in a field reference and replaces it with another.
-	 * <p>
-	 * Argument: true if global sub, false otherwise.
-	 * <p>
-	 * Stack before: field-num regexp replacement-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SUB_FOR_DOLLAR_REFERENCE = 308; // x -> 0
-	/**
-	 * Built-in function that substitutes an occurrence (or all occurrences)
-	 * of a string in a particular variable and replaces it with another.
-	 * <p>
-	 * Argument 1: variable offset in variable manager<br/>
-	 * Argument 2: is global variable<br/>
-	 * Argument 3: is global sub
-	 * <p>
-	 * Stack before: regexp replacement-string orig-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SUB_FOR_VARIABLE = 309; // x -> 0
-	/**
-	 * Built-in function that substitutes an occurrence (or all occurrences)
-	 * of a string in a particular array cell and replaces it with another.
-	 * <p>
-	 * Argument 1: array map offset in variable manager<br/>
-	 * Argument 2: is global array map<br/>
-	 * Argument 3: is global sub
-	 * <p>
-	 * Stack before: array-index regexp replacement-string orig-string ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SUB_FOR_ARRAY_REFERENCE = 310; // x -> 0
-	/**
-	 * Built-in function to split a string by a regexp and put the
-	 * components into an array.
-	 * <p>
-	 * Argument: # of arguments (parameters on stack)
-	 * <p>
-	 * If # of arguments is 2:
-	 * <blockquote>
-	 * Stack before: string array ...<br/>
-	 * Stack after: n ...
-	 * </blockquote>
-	 * else
-	 * <blockquote>
-	 * Stack before: string array regexp ...<br/>
-	 * Stack after: n ...
-	 * </blockquote>
-	 */
-	public static final int SPLIT = 311; // x1 -> x2
-	/**
-	 * Built-in function that pushes a substring of the top-of-stack
-	 * onto the stack.
-	 * The tuple argument indicates whether to limit the substring
-	 * to a particular end position, or to take the substring
-	 * up to the end-of-string.
-	 * <p>
-	 * Argument: # of arguments
-	 * <p>
-	 * If # of arguments is 2:
-	 * <blockquote>
-	 * Stack before: string start-pos ...<br/>
-	 * Stack after: substring ...
-	 * </blockquote>
-	 * else
-	 * <blockquote>
-	 * Stack before: string start-pos end-pos ...<br/>
-	 * Stack after: substring ...
-	 * </blockquote>
-	 */
-	public static final int SUBSTR = 312; // x1 -> x2
-	/**
-	 * Built-in function that converts all the letters in the top-of-stack
-	 * to lower case and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: STRING-ARGUMENT ...<br/>
-	 * Stack after: string-argument ...
-	 */
-	public static final int TOLOWER = 313; // x1 -> x2
-	/**
-	 * Built-in function that converts all the letters in the top-of-stack
-	 * to upper case and pushes the result onto the stack.
-	 * <p>
-	 * Stack before: string-argument ...<br/>
-	 * Stack after: STRING-ARGUMENT ...
-	 */
-	public static final int TOUPPER = 314; // x1 -> x2
-	/**
-	 * Built-in function that executes the top-of-stack as a system command
-	 * and pushes the return code onto the stack.
-	 * <p>
-	 * Stack before: cmd ...<br/>
-	 * Stack after: return-code ...
-	 */
-	public static final int SYSTEM = 315; // x1 -> x2
-
-	/**
-	 * Swaps the top two elements of the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x2 x1 ...
-	 */
-	public static final int SWAP = 316; // x2, x1 -> x1, x2
-
-	/**
-	 * Numerically adds the top two elements of the stack with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1+x2 ...
-	 */
-	public static final int ADD = 317; // x2, x1 -> x1+x2
-	/**
-	 * Numerically subtracts the top two elements of the stack with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1-x2 ...
-	 */
-	public static final int SUBTRACT = 318; // x2, x1 -> x1-x2
-	/**
-	 * Numerically multiplies the top two elements of the stack with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1*x2 ...
-	 */
-	public static final int MULTIPLY = 319; // x2, x1 -> x1*x2
-	/**
-	 * Numerically divides the top two elements of the stack with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1/x2 ...
-	 */
-	public static final int DIVIDE = 320; // x2, x1 -> x1/x2
-	/**
-	 * Numerically takes the modulus of the top two elements of the stack with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1%x2 ...
-	 */
-	public static final int MOD = 321; // x2, x1 -> x1/x2
-	/**
-	 * Numerically raises the top element to the power of the next element with the result
-	 * pushed onto the stack.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1^x2 ...
-	 */
-	public static final int POW = 322; // x2, x1 -> x1/x2
-
-	/**
-	 * Increases the variable reference by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x+1 ...
-	 */
-	public static final int INC = 323; // 0 -> x
-	/**
-	 * Decreases the variable reference by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x-1 ...
-	 */
-	public static final int DEC = 324; // 0 -> x
-	/**
-	 * Increases the array element reference by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx ...<br/>
-	 * Stack after: x+1 ...
-	 */
-	public static final int INC_ARRAY_REF = 325; // x -> x
-	/**
-	 * Decreases the array element reference by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the associative array into the variable manager<br/>
-	 * Argument 2: whether the associative array is global or local
-	 * <p>
-	 * Stack before: array-idx ...<br/>
-	 * Stack after: x-1 ...
-	 */
-	public static final int DEC_ARRAY_REF = 326; // x -> x
-	/**
-	 * Increases the input field variable by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Stack before: field-idx ...<br/>
-	 * Stack after: x+1
-	 */
-	public static final int INC_DOLLAR_REF = 327; // x -> x
-	/**
-	 * Decreases the input field variable by one; pushes the result
-	 * onto the stack.
-	 * <p>
-	 * Stack before: field-idx ...<br/>
-	 * Stack after: x-1
-	 */
-	public static final int DEC_DOLLAR_REF = 328; // x -> x
-
-	/**
-	 * Duplicates the top-of-stack on the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x x ...
-	 */
-	public static final int DUP = 329; // x -> x, x
-	/**
-	 * Evaluates the logical NOT of the top stack element;
-	 * pushes the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: !x ...
-	 */
-	public static final int NOT = 330; // x -> !x
-	/**
-	 * Evaluates the numerical NEGATION of the top stack element;
-	 * pushes the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: -x ...
-	 */
-	public static final int NEGATE = 331; // x -> -x
-
-	/**
-	 * Compares the top two stack elements; pushes 1 onto the stack if equal, 0 if not equal.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1==x2
-	 */
-	public static final int CMP_EQ = 332; // x2, x1 -> x1 == x2
-	/**
-	 * Compares the top two stack elements; pushes 1 onto the stack if x1 &lt; x2, 0 if not equal.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1&lt;x2
-	 */
-	public static final int CMP_LT = 333; // x2, x1 -> x1 < x2
-	/**
-	 * Compares the top two stack elements; pushes 1 onto the stack if x1 &gt; x2, 0 if not equal.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: x1&gt;x2
-	 */
-	public static final int CMP_GT = 334; // x2, x1 -> x1 < x2
-	/**
-	 * Applies a regular expression to the top stack element; pushes 1 if it matches,
-	 * 0 if it does not match.
-	 * <p>
-	 * Stack before: x1 x2 ...<br/>
-	 * Stack after: (x1 ~ /x2/) ...
-	 */
-	public static final int MATCHES = 335; // x2, x1 -> x1 ~ x2
-
-	/**
-	 * <strong>Extension:</strong> Pauses the execution thread by N number of seconds.
-	 * <p>
-	 * Stack before: N ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SLEEP = 336; // x -> 0
-	/** Constant <code>DUMP=337</code> */
-	public static final int DUMP = 337; // x -> 0
-
-	/** Constant <code>DEREF_ARRAY=338</code> */
-	public static final int DEREF_ARRAY = 338; // x -> x
-
-	// for (x in y) {keyset} support
-	/**
-	 * Retrieves and pushes a set of keys from an associative array onto the stack.
-	 * The set is stored in a {@link java.util.Deque} for iteration.
-	 * <p>
-	 * Stack before: associative-array ...<br/>
-	 * Stack after: key-list-set ...
-	 */
-	public static final int KEYLIST = 339; // 0 -> {keylist}
-	/**
-	 * Tests whether the key list (deque) is empty; jumps to the argument
-	 * address if empty, steps to the next instruction if not.
-	 * <p>
-	 * Argument: jump-address-if-empty
-	 * <p>
-	 * Stack before: key-list ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int IS_EMPTY_KEYLIST = 340; // {keylist} -> 0
-	/**
-	 * Removes an item from the key list (deque) and pushes it onto the operand stack.
-	 * <p>
-	 * Stack before: key-list ...<br/>
-	 * Stack after: 1st-item ...
-	 */
-	public static final int GET_FIRST_AND_REMOVE_FROM_KEYLIST = 341; // {keylist} -> x
-
-	// assertions
-	/**
-	 * Checks whether the top-of-stack is of a particular class type;
-	 * if not, an AwkRuntimeException is thrown.
-	 * The stack remains unchanged upon a successful check.
-	 * <p>
-	 * Argument: class-type (i.e., java.util.Deque.class)
-	 * <p>
-	 * Stack before: obj ...<br/>
-	 * Stack after: obj ...
-	 */
-	public static final int CHECK_CLASS = 342; // {class} -> 0
-
-	// input
-	// * Obtain an input string from stdin; push the result onto the stack.
-	/**
-	 * Push an input field onto the stack.
-	 * <p>
-	 * Stack before: field-id ...<br/>
-	 * Stack after: x ...
-	 */
-	public static final int GET_INPUT_FIELD = 343; // 0 -> x
-	/**
-	 * Consume next line of input; assigning $0 and recalculating $1, $2, etc.
-	 * The input can come from the following sources:
-	 * <ul>
-	 * <li>stdin
-	 * <li>filename arguments
-	 * </ul>
-	 * The operand stack is unaffected.
-	 */
-	public static final int CONSUME_INPUT = 344; // 0 -> 0
-	/**
-	 * Obtains input from stdin/filename-args and pushes
-	 * input line and status code onto the stack.
-	 * The input is partitioned into records based on the RS variable
-	 * assignment as a regular expression.
-	 * <p>
-	 * If there is input available, the input string and a return code
-	 * of 1 is pushed. If EOF is reached, a blank (null) string ("")
-	 * is pushed along with a 0 return code. Upon an IO error,
-	 * a blank string and a -1 is pushed onto the operand stack.
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: input-string return-code ...
-	 */
-	public static final int GETLINE_INPUT = 345; // 0 -> x
-	/**
-	 * Obtains input from a file and pushes
-	 * input line and status code onto the stack.
-	 * The input is partitioned into records based on the RS variable
-	 * assignment as a regular expression.
-	 * <p>
-	 * Upon initial execution, the file is opened and the handle
-	 * is maintained until it is explicitly closed, or until
-	 * the VM exits. Subsequent calls will obtain subsequent
-	 * lines (records) of input until no more records are available.
-	 * <p>
-	 * If there is input available, the input string and a return code
-	 * of 1 is pushed. If EOF is reached, a blank (null) string ("")
-	 * is pushed along with a 0 return code. Upon an IO error,
-	 * a blank string and a -1 is pushed onto the operand stack.
-	 * <p>
-	 * Stack before: filename ...<br/>
-	 * Stack after: input-string return-code ...
-	 */
-	public static final int USE_AS_FILE_INPUT = 346; // x1 -> x2
-	/**
-	 * Obtains input from a command (process) and pushes
-	 * input line and status code onto the stack.
-	 * The input is partitioned into records based on the RS variable
-	 * assignment as a regular expression.
-	 * <p>
-	 * Upon initial execution, the a process is spawned to execute
-	 * the specified command and the process reference
-	 * is maintained until it is explicitly closed, or until
-	 * the VM exits. Subsequent calls will obtain subsequent
-	 * lines (records) of input until no more records are available.
-	 * <p>
-	 * If there is input available, the input string and a return code
-	 * of 1 is pushed. If EOF is reached, a blank (null) string ("")
-	 * is pushed along with a 0 return code. Upon an IO error,
-	 * a blank string and a -1 is pushed onto the operand stack.
-	 * <p>
-	 * Stack before: command-line ...<br/>
-	 * Stack after: input-string return-code ...
-	 */
-	public static final int USE_AS_COMMAND_INPUT = 347; // x1 -> x2
-
-	// variable housekeeping
-	/**
-	 * Assign the NF variable offset. This is important for the
-	 * AVM to set the variables as new input lines are processed.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int NF_OFFSET = 348; // 0 -> 0
-	/**
-	 * Assign the NR variable offset. This is important for the
-	 * AVM to increase the record number as new input lines received.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int NR_OFFSET = 349; // 0 -> 0
-	/**
-	 * Assign the FNR variable offset. This is important for the
-	 * AVM to increase the "file" record number as new input lines are received.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int FNR_OFFSET = 350; // 0 -> 0
-	/**
-	 * Assign the FS variable offset. This is important for the
-	 * AVM to know how to split fields upon incoming records of input.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int FS_OFFSET = 351; // 0 -> 0
-	/**
-	 * Assign the RS variable offset. This is important for the
-	 * AVM to know how to create records from the stream(s) of input.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int RS_OFFSET = 352; // 0 -> 0
-	/**
-	 * Assign the OFS variable offset. This is important for the
-	 * AVM to use when outputting expressions via PRINT.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int OFS_OFFSET = 353; // 0 -> 0
-	/**
-	 * Assign the RSTART variable offset. The AVM sets this variable while
-	 * executing the match() builtin function.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int RSTART_OFFSET = 354; // 0 -> 0
-	/**
-	 * Assign the RLENGTH variable offset. The AVM sets this variable while
-	 * executing the match() builtin function.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int RLENGTH_OFFSET = 355; // 0 -> 0
-	/**
-	 * Assign the FILENAME variable offset. The AVM sets this variable while
-	 * processing files from the command-line for input.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int FILENAME_OFFSET = 356; // 0 -> 0
-	/**
-	 * Assign the SUBSEP variable offset. The AVM uses this variable while
-	 * building an index of a multi-dimensional array.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int SUBSEP_OFFSET = 357; // 0 -> 0
-	/**
-	 * Assign the CONVFMT variable offset. The AVM uses this variable while
-	 * converting numbers to strings.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int CONVFMT_OFFSET = 358; // 0 -> 0
-	/**
-	 * Assign the OFMT variable offset. The AVM uses this variable while
-	 * converting numbers to strings for printing.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int OFMT_OFFSET = 359; // 0 -> 0
-	/**
-	 * Assign the ENVIRON variable offset. The AVM provides environment
-	 * variables through this array.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int ENVIRON_OFFSET = 360; // 0 -> 0
-	/**
-	 * Assign the ARGC variable offset. The AVM provides the number of
-	 * arguments via this variable.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int ARGC_OFFSET = 361; // 0 -> 0
-	/**
-	 * Assign the ARGV variable offset. The AVM provides command-line
-	 * arguments via this variable.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int ARGV_OFFSET = 362; // 0 -> 0
-
-	/**
-	 * Apply the RS variable by notifying the partitioning reader that
-	 * there is a new regular expression to use when partitioning input
-	 * records.
-	 * <p>
-	 * The stack remains unaffected.
-	 */
-	public static final int APPLY_RS = 363; // 0 -> 0
-
-	/**
-	 * Call a user function.
-	 * <p>
-	 * Stack before: x1, x2, ..., xn <br>
-	 * Stack after: f(x1, x2, ..., xn)
-	 */
-	public static final int CALL_FUNCTION = 364; // x1,x2,...,xn -> x
-
-	/**
-	 * Define a user function.
-	 * <p>
-	 * Stack remains unchanged
-	 */
-	public static final int FUNCTION = 365; // 0 -> 0
-
-	/**
-	 * Sets the return value of a user function.
-	 * <p>
-	 * Stack before: x <br>
-	 * Stack after: ...
-	 */
-	public static final int SET_RETURN_RESULT = 366; // x -> 0
-
-	/**
-	 * Get the return value of the user function that was called
-	 * <p>
-	 * Stack before: ... <br>
-	 * Stack after: x
-	 */
-	public static final int RETURN_FROM_FUNCTION = 367; // 0 -> x
-
-	/**
-	 * Internal: sets the number of global variables
-	 */
-	public static final int SET_NUM_GLOBALS = 368; // 0 -> 0
-
-	/**
-	 * Close the specified file.
-	 * <p>
-	 * Stack before: file name <br>
-	 * Stack after: result of the close operation
-	 */
-	public static final int CLOSE = 369; // x -> x
-
-	/**
-	 * Convert a list of array indices to a concatenated string with SUBSEP.
-	 * This is used for multidimensional arrays.
-	 * <p>
-	 * Stack before: i1, i2, ..., in <br>
-	 * Stack after: "i1SUBSEPi2SUBSEP...in"
-	 */
-	public static final int APPLY_SUBSEP = 370; // x -> 0
-
-	/**
-	 * Deletes an entry in an array.
-	 * <p>
-	 * Stack before: i <br>
-	 * Stack after: ...
-	 */
-	public static final int DELETE_ARRAY_ELEMENT = 371; // 0 -> 0
-
-	/**
-	 * Internal.
-	 * <p>
-	 * Stack remains unchanged.
-	 */
-	public static final int SET_EXIT_ADDRESS = 372; // 0 -> 0
-
-	/**
-	 * Internal.
-	 * <p>
-	 * Stack remains unchanged.
-	 */
-	public static final int SET_WITHIN_END_BLOCKS = 373; // 0 -> 0
-
-	/**
-	 * Terminates execution and returns specified exit code.
-	 * <p>
-	 * Stack before: integer <br>
-	 * Stack after: N/A
-	 */
-	public static final int EXIT_WITH_CODE = 374; // 0 -> 0
-
-	/**
-	 * Returns a regex pattern.
-	 * <p>
-	 * Stack before: ... <br>
-	 * Stack after: the regex pattern object
-	 */
-	public static final int REGEXP = 375; // 0 -> x
-
-	/**
-	 * Returns a pair of regex patterns.
-	 * <p>
-	 * Stack before: pattern1, pattern2 <br>
-	 * Stack after: regex pair object
-	 */
-	public static final int CONDITION_PAIR = 376; // x, y -> x
-
-	/**
-	 * Returns whether the specified key is in the array.
-	 * <p>
-	 * Stack before: key, array <br>
-	 * Stack after: true|false
-	 */
-	public static final int IS_IN = 377; // x,y -> x
-
-	/**
-	 * Cast to integer
-	 * <p>
-	 * Stack before: object <br>
-	 * Stack after: integer
-	 */
-	public static final int CAST_INT = 378; // x -> (int)x
-
-	/**
-	 * Cast to double
-	 * <p>
-	 * Stack before: object <br>
-	 * Stack after: double
-	 */
-	public static final int CAST_DOUBLE = 379; // x -> (double)x
-
-	/**
-	 * Cast to string
-	 * <p>
-	 * Stack before: object <br>
-	 * Stack after: string
-	 */
-	public static final int CAST_STRING = 380; // x -> (string)x
-
-	/**
-	 * Deprecated.
-	 */
-	public static final int THIS = 381; // 0 -> (this)
-
-	/**
-	 * Call a function from an extension
-	 * <p>
-	 * Stack before: x1, x2, ..., xn <br>
-	 * Stack after: f(x1, x2, ..., xn)
-	 */
-	public static final int EXTENSION = 382; // x1,x2,...,xn -> x
-
-	/**
-	 * Execute the specified AWK code
-	 * <p>
-	 * Stack before: script <br>
-	 * Stack after: exit code of the script, or zero when successful, -1 when failed
-	 */
-	public static final int EXEC = 383; // x1,x2,...,xn -> x
-
-	/**
-	 * Delete the specified array.
-	 * <p>
-	 * Stack remains unchanged.
-	 */
-	public static final int DELETE_ARRAY = 384; // 0 -> 0
-
-	/**
-	 * Converts the top stack element to a number;
-	 * pushes the result onto the stack.
-	 * <p>
-	 * Stack before: x ...<br/>
-	 * Stack after: x ... (as a number)
-	 */
-	public static final int UNARY_PLUS = 385; // x -> -x
-
-	/**
-	 * Terminates execution without specifying an exit code.
-	 * <p>
-	 * Stack before: N/A <br>
-	 * Stack after: N/A
-	 */
-	public static final int EXIT_WITHOUT_CODE = 386; // 0 -> 0
-
-	/**
-	 * Assign the ORS variable offset. This is important for the
-	 * AVM to use when outputting expressions via PRINT.
-	 * <p>
-	 * The operand stack is unaffected.
-	 */
-	public static final int ORS_OFFSET = 387; // 0 -> 0
-
-	/**
-	 * Increases the variable reference by one; pushes the original value
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x ... or 0 if uninitialized
-	 */
-	public static final int POSTINC = 388; // 0 -> x
-
-	/**
-	 * Decreases the variable reference by one; pushes the original value
-	 * onto the stack.
-	 * <p>
-	 * Argument 1: offset of the particular variable into the variable manager<br/>
-	 * Argument 2: whether the variable is global or local
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: x ... or 0 if uninitialized
-	 */
-	public static final int POSTDEC = 389; // 0 -> x
-
-	/**
-	 * Read stdin for simple AWK expression evaluation.
-	 * <p>
-	 * Stack before: ...<br/>
-	 * Stack after: ...
-	 */
-	public static final int SET_INPUT_FOR_EVAL = 390; // 0 -> 0
-	// CHECKSTYLE:ON
 
 	/**
 	 * Override add() to populate the line number for each tuple,
@@ -1334,21 +79,7 @@ public class AwkTuples implements Serializable {
 	 * @return a {@link java.lang.String} object
 	 */
 	public static String toOpcodeString(int opcode) {
-		Class<?> c = AwkTuples.class;
-		Field[] fields = c.getDeclaredFields();
-		try {
-			for (Field field : fields) {
-				if ((field.getModifiers() & Modifier.STATIC) > 0
-						&& field.getType() == Long.TYPE
-						&& field.getLong(null) == opcode) {
-					return field.getName();
-				}
-			}
-		} catch (IllegalAccessException iac) {
-			LOGGER.error("Failed to create OP-Code string", iac);
-			return "[" + opcode + ": " + iac + "]";
-		}
-		return "{" + opcode + "}";
+		return Opcode.fromId(opcode).name();
 	}
 
 	/**
@@ -1357,7 +88,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void pop() {
-		queue.add(new Tuple(POP));
+		queue.add(new Tuple(Opcode.POP));
 	}
 
 	/**
@@ -1372,13 +103,13 @@ public class AwkTuples implements Serializable {
 																																																						// instanceof
 																																																						// Pattern);
 		if (o instanceof String) {
-			queue.add(new Tuple(PUSH, o.toString()));
+			queue.add(new Tuple(Opcode.PUSH, o.toString()));
 		} else if (o instanceof Integer) {
-			queue.add(new Tuple(PUSH, (Integer) o));
+			queue.add(new Tuple(Opcode.PUSH, (Integer) o));
 		} else if (o instanceof Long) {
-			queue.add(new Tuple(PUSH, (Long) o));
+			queue.add(new Tuple(Opcode.PUSH, (Long) o));
 		} else if (o instanceof Double) {
-			queue.add(new Tuple(PUSH, (Double) o));
+			queue.add(new Tuple(Opcode.PUSH, (Double) o));
 		} else {
 			assert false : "Invalid type for " + o + ", " + o.getClass();
 		}
@@ -1392,7 +123,7 @@ public class AwkTuples implements Serializable {
 	 * @param address a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void ifFalse(Address address) {
-		queue.add(new Tuple(IFFALSE, address));
+		queue.add(new Tuple(Opcode.IFFALSE, address));
 	}
 
 	/**
@@ -1401,7 +132,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void toNumber() {
-		queue.add(new Tuple(TO_NUMBER));
+		queue.add(new Tuple(Opcode.TO_NUMBER));
 	}
 
 	/**
@@ -1412,7 +143,7 @@ public class AwkTuples implements Serializable {
 	 * @param address a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void ifTrue(Address address) {
-		queue.add(new Tuple(IFTRUE, address));
+		queue.add(new Tuple(Opcode.IFTRUE, address));
 	}
 
 	/**
@@ -1423,7 +154,7 @@ public class AwkTuples implements Serializable {
 	 * @param address a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void gotoAddress(Address address) {
-		queue.add(new Tuple(GOTO, address));
+		queue.add(new Tuple(Opcode.GOTO, address));
 	}
 
 	/**
@@ -1457,7 +188,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void nop() {
-		queue.add(new Tuple(NOP));
+		queue.add(new Tuple(Opcode.NOP));
 	}
 
 	/**
@@ -1468,7 +199,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void print(int numExprs) {
-		queue.add(new Tuple(PRINT, numExprs));
+		queue.add(new Tuple(Opcode.PRINT, numExprs));
 	}
 
 	/**
@@ -1480,7 +211,7 @@ public class AwkTuples implements Serializable {
 	 * @param append a boolean
 	 */
 	public void printToFile(int numExprs, boolean append) {
-		queue.add(new Tuple(PRINT_TO_FILE, numExprs, append));
+		queue.add(new Tuple(Opcode.PRINT_TO_FILE, numExprs, append));
 	}
 
 	/**
@@ -1491,7 +222,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void printToPipe(int numExprs) {
-		queue.add(new Tuple(PRINT_TO_PIPE, numExprs));
+		queue.add(new Tuple(Opcode.PRINT_TO_PIPE, numExprs));
 	}
 
 	/**
@@ -1502,7 +233,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void printf(int numExprs) {
-		queue.add(new Tuple(PRINTF, numExprs));
+		queue.add(new Tuple(Opcode.PRINTF, numExprs));
 	}
 
 	/**
@@ -1514,7 +245,7 @@ public class AwkTuples implements Serializable {
 	 * @param append a boolean
 	 */
 	public void printfToFile(int numExprs, boolean append) {
-		queue.add(new Tuple(PRINTF_TO_FILE, numExprs, append));
+		queue.add(new Tuple(Opcode.PRINTF_TO_FILE, numExprs, append));
 	}
 
 	/**
@@ -1525,7 +256,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void printfToPipe(int numExprs) {
-		queue.add(new Tuple(PRINTF_TO_PIPE, numExprs));
+		queue.add(new Tuple(Opcode.PRINTF_TO_PIPE, numExprs));
 	}
 
 	/**
@@ -1536,7 +267,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void sprintf(int numExprs) {
-		queue.add(new Tuple(SPRINTF, numExprs));
+		queue.add(new Tuple(Opcode.SPRINTF, numExprs));
 	}
 
 	/**
@@ -1547,7 +278,7 @@ public class AwkTuples implements Serializable {
 	 * @param numExprs a int
 	 */
 	public void length(int numExprs) {
-		queue.add(new Tuple(LENGTH, numExprs));
+		queue.add(new Tuple(Opcode.LENGTH, numExprs));
 	}
 
 	/**
@@ -1556,7 +287,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void concat() {
-		queue.add(new Tuple(CONCAT));
+		queue.add(new Tuple(Opcode.CONCAT));
 	}
 
 	/**
@@ -1568,7 +299,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void assign(int offset, boolean isGlobal) {
-		queue.add(new Tuple(ASSIGN, offset, isGlobal));
+		queue.add(new Tuple(Opcode.ASSIGN, offset, isGlobal));
 	}
 
 	/**
@@ -1580,7 +311,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void assignArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(ASSIGN_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.ASSIGN_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1589,14 +320,14 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void assignAsInput() {
-		queue.add(new Tuple(ASSIGN_AS_INPUT));
+		queue.add(new Tuple(Opcode.ASSIGN_AS_INPUT));
 	}
 
 	/**
 	 * Use this only in initialization for simple evaluation
 	 */
 	public void setInputForEval() {
-		queue.add(new Tuple(SET_INPUT_FOR_EVAL));
+		queue.add(new Tuple(Opcode.SET_INPUT_FOR_EVAL));
 	}
 
 	/**
@@ -1605,7 +336,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void assignAsInputField() {
-		queue.add(new Tuple(ASSIGN_AS_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.ASSIGN_AS_INPUT_FIELD));
 	}
 
 	/**
@@ -1618,7 +349,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void dereference(int offset, boolean isArray, boolean isGlobal) {
-		queue.add(new Tuple(DEREFERENCE, offset, isArray, isGlobal));
+		queue.add(new Tuple(Opcode.DEREFERENCE, offset, isArray, isGlobal));
 	}
 
 	/**
@@ -1630,7 +361,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void plusEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(PLUS_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.PLUS_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1642,7 +373,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void minusEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MINUS_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MINUS_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1654,7 +385,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void multEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MULT_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MULT_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1666,7 +397,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void divEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DIV_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DIV_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1678,7 +409,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void modEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MOD_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MOD_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1690,7 +421,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void powEq(int offset, boolean isGlobal) {
-		queue.add(new Tuple(POW_EQ, offset, isGlobal));
+		queue.add(new Tuple(Opcode.POW_EQ, offset, isGlobal));
 	}
 
 	/**
@@ -1702,7 +433,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void plusEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(PLUS_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.PLUS_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1714,7 +445,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void minusEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MINUS_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MINUS_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1726,7 +457,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void multEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MULT_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MULT_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1738,7 +469,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void divEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DIV_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DIV_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1750,7 +481,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void modEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(MOD_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.MOD_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1762,7 +493,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void powEqArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(POW_EQ_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.POW_EQ_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -1771,7 +502,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void plusEqInputField() {
-		queue.add(new Tuple(PLUS_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.PLUS_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1780,7 +511,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void minusEqInputField() {
-		queue.add(new Tuple(MINUS_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.MINUS_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1789,7 +520,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void multEqInputField() {
-		queue.add(new Tuple(MULT_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.MULT_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1798,7 +529,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void divEqInputField() {
-		queue.add(new Tuple(DIV_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.DIV_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1807,7 +538,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void modEqInputField() {
-		queue.add(new Tuple(MOD_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.MOD_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1816,7 +547,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void powEqInputField() {
-		queue.add(new Tuple(POW_EQ_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.POW_EQ_INPUT_FIELD));
 	}
 
 	/**
@@ -1827,7 +558,7 @@ public class AwkTuples implements Serializable {
 	 * @param num a int
 	 */
 	public void srand(int num) {
-		queue.add(new Tuple(SRAND, num));
+		queue.add(new Tuple(Opcode.SRAND, num));
 	}
 
 	/**
@@ -1836,7 +567,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void rand() {
-		queue.add(new Tuple(RAND));
+		queue.add(new Tuple(Opcode.RAND));
 	}
 
 	/**
@@ -1845,7 +576,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void intFunc() {
-		queue.add(new Tuple(INTFUNC));
+		queue.add(new Tuple(Opcode.INTFUNC));
 	}
 
 	/**
@@ -1854,7 +585,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void sqrt() {
-		queue.add(new Tuple(SQRT));
+		queue.add(new Tuple(Opcode.SQRT));
 	}
 
 	/**
@@ -1863,7 +594,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void log() {
-		queue.add(new Tuple(LOG));
+		queue.add(new Tuple(Opcode.LOG));
 	}
 
 	/**
@@ -1872,7 +603,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void exp() {
-		queue.add(new Tuple(EXP));
+		queue.add(new Tuple(Opcode.EXP));
 	}
 
 	/**
@@ -1881,7 +612,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void sin() {
-		queue.add(new Tuple(SIN));
+		queue.add(new Tuple(Opcode.SIN));
 	}
 
 	/**
@@ -1890,7 +621,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void cos() {
-		queue.add(new Tuple(COS));
+		queue.add(new Tuple(Opcode.COS));
 	}
 
 	/**
@@ -1899,7 +630,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void atan2() {
-		queue.add(new Tuple(ATAN2));
+		queue.add(new Tuple(Opcode.ATAN2));
 	}
 
 	/**
@@ -1908,7 +639,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void match() {
-		queue.add(new Tuple(MATCH));
+		queue.add(new Tuple(Opcode.MATCH));
 	}
 
 	/**
@@ -1917,7 +648,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void index() {
-		queue.add(new Tuple(INDEX));
+		queue.add(new Tuple(Opcode.INDEX));
 	}
 
 	/**
@@ -1928,7 +659,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGsub a boolean
 	 */
 	public void subForDollar0(boolean isGsub) {
-		queue.add(new Tuple(SUB_FOR_DOLLAR_0, isGsub));
+		queue.add(new Tuple(Opcode.SUB_FOR_DOLLAR_0, isGsub));
 	}
 
 	/**
@@ -1939,7 +670,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGsub a boolean
 	 */
 	public void subForDollarReference(boolean isGsub) {
-		queue.add(new Tuple(SUB_FOR_DOLLAR_REFERENCE, isGsub));
+		queue.add(new Tuple(Opcode.SUB_FOR_DOLLAR_REFERENCE, isGsub));
 	}
 
 	/**
@@ -1952,7 +683,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGsub a boolean
 	 */
 	public void subForVariable(int offset, boolean isGlobal, boolean isGsub) {
-		queue.add(new Tuple(SUB_FOR_VARIABLE, offset, isGlobal, isGsub));
+		queue.add(new Tuple(Opcode.SUB_FOR_VARIABLE, offset, isGlobal, isGsub));
 	}
 
 	/**
@@ -1965,7 +696,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGsub a boolean
 	 */
 	public void subForArrayReference(int offset, boolean isGlobal, boolean isGsub) {
-		queue.add(new Tuple(SUB_FOR_ARRAY_REFERENCE, offset, isGlobal, isGsub));
+		queue.add(new Tuple(Opcode.SUB_FOR_ARRAY_REFERENCE, offset, isGlobal, isGsub));
 	}
 
 	/**
@@ -1976,7 +707,7 @@ public class AwkTuples implements Serializable {
 	 * @param numargs a int
 	 */
 	public void split(int numargs) {
-		queue.add(new Tuple(SPLIT, numargs));
+		queue.add(new Tuple(Opcode.SPLIT, numargs));
 	}
 
 	/**
@@ -1987,7 +718,7 @@ public class AwkTuples implements Serializable {
 	 * @param numargs a int
 	 */
 	public void substr(int numargs) {
-		queue.add(new Tuple(SUBSTR, numargs));
+		queue.add(new Tuple(Opcode.SUBSTR, numargs));
 	}
 
 	/**
@@ -1996,7 +727,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void tolower() {
-		queue.add(new Tuple(TOLOWER));
+		queue.add(new Tuple(Opcode.TOLOWER));
 	}
 
 	/**
@@ -2005,7 +736,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void toupper() {
-		queue.add(new Tuple(TOUPPER));
+		queue.add(new Tuple(Opcode.TOUPPER));
 	}
 
 	/**
@@ -2014,7 +745,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void system() {
-		queue.add(new Tuple(SYSTEM));
+		queue.add(new Tuple(Opcode.SYSTEM));
 	}
 
 	/**
@@ -2023,7 +754,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void exec() {
-		queue.add(new Tuple(EXEC));
+		queue.add(new Tuple(Opcode.EXEC));
 	}
 
 	/**
@@ -2032,7 +763,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void swap() {
-		queue.add(new Tuple(SWAP));
+		queue.add(new Tuple(Opcode.SWAP));
 	}
 
 	/**
@@ -2041,7 +772,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void add() {
-		queue.add(new Tuple(ADD));
+		queue.add(new Tuple(Opcode.ADD));
 	}
 
 	/**
@@ -2050,7 +781,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void subtract() {
-		queue.add(new Tuple(SUBTRACT));
+		queue.add(new Tuple(Opcode.SUBTRACT));
 	}
 
 	/**
@@ -2059,7 +790,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void multiply() {
-		queue.add(new Tuple(MULTIPLY));
+		queue.add(new Tuple(Opcode.MULTIPLY));
 	}
 
 	/**
@@ -2068,7 +799,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void divide() {
-		queue.add(new Tuple(DIVIDE));
+		queue.add(new Tuple(Opcode.DIVIDE));
 	}
 
 	/**
@@ -2077,7 +808,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void mod() {
-		queue.add(new Tuple(MOD));
+		queue.add(new Tuple(Opcode.MOD));
 	}
 
 	/**
@@ -2086,7 +817,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void pow() {
-		queue.add(new Tuple(POW));
+		queue.add(new Tuple(Opcode.POW));
 	}
 
 	/**
@@ -2098,7 +829,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void inc(int offset, boolean isGlobal) {
-		queue.add(new Tuple(INC, offset, isGlobal));
+		queue.add(new Tuple(Opcode.INC, offset, isGlobal));
 	}
 
 	/**
@@ -2110,7 +841,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void dec(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DEC, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DEC, offset, isGlobal));
 	}
 
 	/**
@@ -2122,7 +853,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void postInc(int offset, boolean isGlobal) {
-		queue.add(new Tuple(POSTINC, offset, isGlobal));
+		queue.add(new Tuple(Opcode.POSTINC, offset, isGlobal));
 	}
 
 	/**
@@ -2134,7 +865,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void postDec(int offset, boolean isGlobal) {
-		queue.add(new Tuple(POSTDEC, offset, isGlobal));
+		queue.add(new Tuple(Opcode.POSTDEC, offset, isGlobal));
 	}
 
 	/**
@@ -2146,7 +877,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void incArrayRef(int offset, boolean isGlobal) {
-		queue.add(new Tuple(INC_ARRAY_REF, offset, isGlobal));
+		queue.add(new Tuple(Opcode.INC_ARRAY_REF, offset, isGlobal));
 	}
 
 	/**
@@ -2158,7 +889,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void decArrayRef(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DEC_ARRAY_REF, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DEC_ARRAY_REF, offset, isGlobal));
 	}
 
 	/**
@@ -2167,7 +898,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void incDollarRef() {
-		queue.add(new Tuple(INC_DOLLAR_REF));
+		queue.add(new Tuple(Opcode.INC_DOLLAR_REF));
 	}
 
 	/**
@@ -2176,7 +907,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void decDollarRef() {
-		queue.add(new Tuple(DEC_DOLLAR_REF));
+		queue.add(new Tuple(Opcode.DEC_DOLLAR_REF));
 	}
 
 	/**
@@ -2185,7 +916,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void dup() {
-		queue.add(new Tuple(DUP));
+		queue.add(new Tuple(Opcode.DUP));
 	}
 
 	/**
@@ -2194,7 +925,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void not() {
-		queue.add(new Tuple(NOT));
+		queue.add(new Tuple(Opcode.NOT));
 	}
 
 	/**
@@ -2203,7 +934,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void negate() {
-		queue.add(new Tuple(NEGATE));
+		queue.add(new Tuple(Opcode.NEGATE));
 	}
 
 	/**
@@ -2212,7 +943,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void unaryPlus() {
-		queue.add(new Tuple(UNARY_PLUS));
+		queue.add(new Tuple(Opcode.UNARY_PLUS));
 	}
 
 	/**
@@ -2221,7 +952,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void cmpEq() {
-		queue.add(new Tuple(CMP_EQ));
+		queue.add(new Tuple(Opcode.CMP_EQ));
 	}
 
 	/**
@@ -2230,7 +961,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void cmpLt() {
-		queue.add(new Tuple(CMP_LT));
+		queue.add(new Tuple(Opcode.CMP_LT));
 	}
 
 	/**
@@ -2239,7 +970,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void cmpGt() {
-		queue.add(new Tuple(CMP_GT));
+		queue.add(new Tuple(Opcode.CMP_GT));
 	}
 
 	/**
@@ -2248,7 +979,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void matches() {
-		queue.add(new Tuple(MATCHES));
+		queue.add(new Tuple(Opcode.MATCHES));
 	}
 
 	/**
@@ -2259,7 +990,7 @@ public class AwkTuples implements Serializable {
 	 * @param numArgs a int
 	 */
 	public void sleep(int numArgs) {
-		queue.add(new Tuple(SLEEP, numArgs));
+		queue.add(new Tuple(Opcode.SLEEP, numArgs));
 	}
 
 	/**
@@ -2270,7 +1001,7 @@ public class AwkTuples implements Serializable {
 	 * @param numArgs a int
 	 */
 	public void dump(int numArgs) {
-		queue.add(new Tuple(DUMP, numArgs));
+		queue.add(new Tuple(Opcode.DUMP, numArgs));
 	}
 
 	/**
@@ -2279,7 +1010,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void dereferenceArray() {
-		queue.add(new Tuple(DEREF_ARRAY));
+		queue.add(new Tuple(Opcode.DEREF_ARRAY));
 	}
 
 	/**
@@ -2288,7 +1019,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void keylist() {
-		queue.add(new Tuple(KEYLIST));
+		queue.add(new Tuple(Opcode.KEYLIST));
 	}
 
 	/**
@@ -2299,7 +1030,7 @@ public class AwkTuples implements Serializable {
 	 * @param address a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void isEmptyList(Address address) {
-		queue.add(new Tuple(IS_EMPTY_KEYLIST, address));
+		queue.add(new Tuple(Opcode.IS_EMPTY_KEYLIST, address));
 	}
 
 	/**
@@ -2308,7 +1039,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void getFirstAndRemoveFromList() {
-		queue.add(new Tuple(GET_FIRST_AND_REMOVE_FROM_KEYLIST));
+		queue.add(new Tuple(Opcode.GET_FIRST_AND_REMOVE_FROM_KEYLIST));
 	}
 
 	/**
@@ -2320,7 +1051,7 @@ public class AwkTuples implements Serializable {
 	 * @return a boolean
 	 */
 	public boolean checkClass(Class<?> cls) {
-		queue.add(new Tuple(CHECK_CLASS, cls));
+		queue.add(new Tuple(Opcode.CHECK_CLASS, cls));
 		return true;
 	}
 
@@ -2330,7 +1061,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void getInputField() {
-		queue.add(new Tuple(GET_INPUT_FIELD));
+		queue.add(new Tuple(Opcode.GET_INPUT_FIELD));
 	}
 
 	/**
@@ -2341,7 +1072,7 @@ public class AwkTuples implements Serializable {
 	 * @param address a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void consumeInput(Address address) {
-		queue.add(new Tuple(CONSUME_INPUT, address));
+		queue.add(new Tuple(Opcode.CONSUME_INPUT, address));
 	}
 
 	/**
@@ -2350,7 +1081,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void getlineInput() {
-		queue.add(new Tuple(GETLINE_INPUT));
+		queue.add(new Tuple(Opcode.GETLINE_INPUT));
 	}
 
 	/**
@@ -2359,7 +1090,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void useAsFileInput() {
-		queue.add(new Tuple(USE_AS_FILE_INPUT));
+		queue.add(new Tuple(Opcode.USE_AS_FILE_INPUT));
 	}
 
 	/**
@@ -2368,7 +1099,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void useAsCommandInput() {
-		queue.add(new Tuple(USE_AS_COMMAND_INPUT));
+		queue.add(new Tuple(Opcode.USE_AS_COMMAND_INPUT));
 	}
 
 	/**
@@ -2379,7 +1110,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void nfOffset(int offset) {
-		queue.add(new Tuple(NF_OFFSET, offset));
+		queue.add(new Tuple(Opcode.NF_OFFSET, offset));
 	}
 
 	/**
@@ -2390,7 +1121,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void nrOffset(int offset) {
-		queue.add(new Tuple(NR_OFFSET, offset));
+		queue.add(new Tuple(Opcode.NR_OFFSET, offset));
 	}
 
 	/**
@@ -2401,7 +1132,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void fnrOffset(int offset) {
-		queue.add(new Tuple(FNR_OFFSET, offset));
+		queue.add(new Tuple(Opcode.FNR_OFFSET, offset));
 	}
 
 	/**
@@ -2412,7 +1143,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void fsOffset(int offset) {
-		queue.add(new Tuple(FS_OFFSET, offset));
+		queue.add(new Tuple(Opcode.FS_OFFSET, offset));
 	}
 
 	/**
@@ -2423,7 +1154,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void rsOffset(int offset) {
-		queue.add(new Tuple(RS_OFFSET, offset));
+		queue.add(new Tuple(Opcode.RS_OFFSET, offset));
 	}
 
 	/**
@@ -2434,7 +1165,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void ofsOffset(int offset) {
-		queue.add(new Tuple(OFS_OFFSET, offset));
+		queue.add(new Tuple(Opcode.OFS_OFFSET, offset));
 	}
 
 	/**
@@ -2445,7 +1176,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void orsOffset(int offset) {
-		queue.add(new Tuple(ORS_OFFSET, offset));
+		queue.add(new Tuple(Opcode.ORS_OFFSET, offset));
 	}
 
 	/**
@@ -2456,7 +1187,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void rstartOffset(int offset) {
-		queue.add(new Tuple(RSTART_OFFSET, offset));
+		queue.add(new Tuple(Opcode.RSTART_OFFSET, offset));
 	}
 
 	/**
@@ -2467,7 +1198,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void rlengthOffset(int offset) {
-		queue.add(new Tuple(RLENGTH_OFFSET, offset));
+		queue.add(new Tuple(Opcode.RLENGTH_OFFSET, offset));
 	}
 
 	/**
@@ -2478,7 +1209,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void filenameOffset(int offset) {
-		queue.add(new Tuple(FILENAME_OFFSET, offset));
+		queue.add(new Tuple(Opcode.FILENAME_OFFSET, offset));
 	}
 
 	/**
@@ -2489,7 +1220,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void subsepOffset(int offset) {
-		queue.add(new Tuple(SUBSEP_OFFSET, offset));
+		queue.add(new Tuple(Opcode.SUBSEP_OFFSET, offset));
 	}
 
 	/**
@@ -2500,7 +1231,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void convfmtOffset(int offset) {
-		queue.add(new Tuple(CONVFMT_OFFSET, offset));
+		queue.add(new Tuple(Opcode.CONVFMT_OFFSET, offset));
 	}
 
 	/**
@@ -2511,7 +1242,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void ofmtOffset(int offset) {
-		queue.add(new Tuple(OFMT_OFFSET, offset));
+		queue.add(new Tuple(Opcode.OFMT_OFFSET, offset));
 	}
 
 	/**
@@ -2522,7 +1253,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void environOffset(int offset) {
-		queue.add(new Tuple(ENVIRON_OFFSET, offset));
+		queue.add(new Tuple(Opcode.ENVIRON_OFFSET, offset));
 	}
 
 	/**
@@ -2533,7 +1264,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void argcOffset(int offset) {
-		queue.add(new Tuple(ARGC_OFFSET, offset));
+		queue.add(new Tuple(Opcode.ARGC_OFFSET, offset));
 	}
 
 	/**
@@ -2544,7 +1275,7 @@ public class AwkTuples implements Serializable {
 	 * @param offset a int
 	 */
 	public void argvOffset(int offset) {
-		queue.add(new Tuple(ARGV_OFFSET, offset));
+		queue.add(new Tuple(Opcode.ARGV_OFFSET, offset));
 	}
 
 	/**
@@ -2553,7 +1284,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void applyRS() {
-		queue.add(new Tuple(APPLY_RS));
+		queue.add(new Tuple(Opcode.APPLY_RS));
 	}
 
 	/**
@@ -2565,11 +1296,11 @@ public class AwkTuples implements Serializable {
 	 * @param numFormalParams a int
 	 */
 	public void function(String funcName, int numFormalParams) {
-		queue.add(new Tuple(FUNCTION, funcName, numFormalParams));
+		queue.add(new Tuple(Opcode.FUNCTION, funcName, numFormalParams));
 	}
 
 	// public void callFunction(Address addr, String funcName, int numFormalParams, int numActualParams) {
-	// queue.add(new Tuple(CALL_FUNCTION, addr, funcName, numFormalParams, numActualParams)); }
+	// queue.add(new Tuple(Opcode.CALL_FUNCTION, addr, funcName, numFormalParams, numActualParams)); }
 
 	/**
 	 * <p>
@@ -2586,7 +1317,7 @@ public class AwkTuples implements Serializable {
 			String funcName,
 			int numFormalParams,
 			int numActualParams) {
-		queue.add(new Tuple(CALL_FUNCTION, addressSupplier, funcName, numFormalParams, numActualParams));
+		queue.add(new Tuple(Opcode.CALL_FUNCTION, addressSupplier, funcName, numFormalParams, numActualParams));
 	}
 
 	/**
@@ -2595,7 +1326,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void setReturnResult() {
-		queue.add(new Tuple(SET_RETURN_RESULT));
+		queue.add(new Tuple(Opcode.SET_RETURN_RESULT));
 	}
 
 	/**
@@ -2604,7 +1335,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void returnFromFunction() {
-		queue.add(new Tuple(RETURN_FROM_FUNCTION));
+		queue.add(new Tuple(Opcode.RETURN_FROM_FUNCTION));
 	}
 
 	/**
@@ -2615,7 +1346,7 @@ public class AwkTuples implements Serializable {
 	 * @param numGlobals a int
 	 */
 	public void setNumGlobals(int numGlobals) {
-		queue.add(new Tuple(SET_NUM_GLOBALS, numGlobals));
+		queue.add(new Tuple(Opcode.SET_NUM_GLOBALS, numGlobals));
 	}
 
 	/**
@@ -2624,7 +1355,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void close() {
-		queue.add(new Tuple(CLOSE));
+		queue.add(new Tuple(Opcode.CLOSE));
 	}
 
 	/**
@@ -2635,7 +1366,7 @@ public class AwkTuples implements Serializable {
 	 * @param count a int
 	 */
 	public void applySubsep(int count) {
-		queue.add(new Tuple(APPLY_SUBSEP, count));
+		queue.add(new Tuple(Opcode.APPLY_SUBSEP, count));
 	}
 
 	/**
@@ -2647,7 +1378,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void deleteArrayElement(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DELETE_ARRAY_ELEMENT, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DELETE_ARRAY_ELEMENT, offset, isGlobal));
 	}
 
 	/**
@@ -2659,7 +1390,7 @@ public class AwkTuples implements Serializable {
 	 * @param isGlobal a boolean
 	 */
 	public void deleteArray(int offset, boolean isGlobal) {
-		queue.add(new Tuple(DELETE_ARRAY, offset, isGlobal));
+		queue.add(new Tuple(Opcode.DELETE_ARRAY, offset, isGlobal));
 	}
 
 	/**
@@ -2670,7 +1401,7 @@ public class AwkTuples implements Serializable {
 	 * @param addr a {@link org.metricshub.jawk.intermediate.Address} object
 	 */
 	public void setExitAddress(Address addr) {
-		queue.add(new Tuple(SET_EXIT_ADDRESS, addr));
+		queue.add(new Tuple(Opcode.SET_EXIT_ADDRESS, addr));
 	}
 
 	/**
@@ -2681,7 +1412,7 @@ public class AwkTuples implements Serializable {
 	 * @param b a boolean
 	 */
 	public void setWithinEndBlocks(boolean b) {
-		queue.add(new Tuple(SET_WITHIN_END_BLOCKS, b));
+		queue.add(new Tuple(Opcode.SET_WITHIN_END_BLOCKS, b));
 	}
 
 	/**
@@ -2690,7 +1421,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void exitWithCode() {
-		queue.add(new Tuple(EXIT_WITH_CODE));
+		queue.add(new Tuple(Opcode.EXIT_WITH_CODE));
 	}
 
 	/**
@@ -2699,7 +1430,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void exitWithoutCode() {
-		queue.add(new Tuple(EXIT_WITHOUT_CODE));
+		queue.add(new Tuple(Opcode.EXIT_WITHOUT_CODE));
 	}
 
 	/**
@@ -2710,7 +1441,7 @@ public class AwkTuples implements Serializable {
 	 * @param regexpStr a {@link java.lang.String} object
 	 */
 	public void regexp(String regexpStr) {
-		queue.add(new Tuple(REGEXP, regexpStr));
+		queue.add(new Tuple(Opcode.REGEXP, regexpStr));
 	}
 
 	/**
@@ -2719,7 +1450,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void conditionPair() {
-		queue.add(new Tuple(CONDITION_PAIR));
+		queue.add(new Tuple(Opcode.CONDITION_PAIR));
 	}
 
 	/**
@@ -2728,7 +1459,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void isIn() {
-		queue.add(new Tuple(IS_IN));
+		queue.add(new Tuple(Opcode.IS_IN));
 	}
 
 	/**
@@ -2737,7 +1468,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void castInt() {
-		queue.add(new Tuple(CAST_INT));
+		queue.add(new Tuple(Opcode.CAST_INT));
 	}
 
 	/**
@@ -2746,7 +1477,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void castDouble() {
-		queue.add(new Tuple(CAST_DOUBLE));
+		queue.add(new Tuple(Opcode.CAST_DOUBLE));
 	}
 
 	/**
@@ -2755,7 +1486,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void castString() {
-		queue.add(new Tuple(CAST_STRING));
+		queue.add(new Tuple(Opcode.CAST_STRING));
 	}
 
 	/**
@@ -2764,7 +1495,7 @@ public class AwkTuples implements Serializable {
 	 * </p>
 	 */
 	public void scriptThis() {
-		queue.add(new Tuple(THIS));
+		queue.add(new Tuple(Opcode.THIS));
 	}
 
 	/**
@@ -2777,7 +1508,7 @@ public class AwkTuples implements Serializable {
 	 * @param isInitial a boolean
 	 */
 	public void extension(String extensionKeyword, int paramCount, boolean isInitial) {
-		queue.add(new Tuple(EXTENSION, extensionKeyword, paramCount, isInitial));
+		queue.add(new Tuple(Opcode.EXTENSION, extensionKeyword, paramCount, isInitial));
 	}
 
 	/**
@@ -2868,7 +1599,7 @@ public class AwkTuples implements Serializable {
 	 */
 	public void setFunctionNameSet(Set<String> names) {
 		// setFunctionNameSet is called with a keySet from
-		// a HashMap as a parameter, which is NOT
+		// a HashMap as a parameter, which is Opcode.NOT
 		// Serializable. Creating a new HashSet around
 		// the parameter resolves the issue.
 		// Otherwise, attempting to serialize this

--- a/src/main/java/org/metricshub/jawk/intermediate/Opcode.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/Opcode.java
@@ -1,0 +1,189 @@
+package org.metricshub.jawk.intermediate;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.Map;
+import java.util.HashMap;
+
+public enum Opcode {
+	POP(257),
+	PUSH(258),
+	IFFALSE(259),
+	TO_NUMBER(260),
+	IFTRUE(261),
+	GOTO(262),
+	NOP(263),
+	PRINT(264),
+	PRINT_TO_FILE(265),
+	PRINT_TO_PIPE(266),
+	PRINTF(267),
+	PRINTF_TO_FILE(268),
+	PRINTF_TO_PIPE(269),
+	SPRINTF(270),
+	LENGTH(271),
+	CONCAT(272),
+	ASSIGN(273),
+	ASSIGN_ARRAY(274),
+	ASSIGN_AS_INPUT(275),
+	ASSIGN_AS_INPUT_FIELD(276),
+	DEREFERENCE(277),
+	PLUS_EQ(278),
+	MINUS_EQ(279),
+	MULT_EQ(280),
+	DIV_EQ(281),
+	MOD_EQ(282),
+	POW_EQ(283),
+	PLUS_EQ_ARRAY(284),
+	MINUS_EQ_ARRAY(285),
+	MULT_EQ_ARRAY(286),
+	DIV_EQ_ARRAY(287),
+	MOD_EQ_ARRAY(288),
+	POW_EQ_ARRAY(289),
+	PLUS_EQ_INPUT_FIELD(290),
+	MINUS_EQ_INPUT_FIELD(291),
+	MULT_EQ_INPUT_FIELD(292),
+	DIV_EQ_INPUT_FIELD(293),
+	MOD_EQ_INPUT_FIELD(294),
+	POW_EQ_INPUT_FIELD(295),
+	SRAND(296),
+	RAND(297),
+	INTFUNC(298),
+	SQRT(299),
+	LOG(300),
+	EXP(301),
+	SIN(302),
+	COS(303),
+	ATAN2(304),
+	MATCH(305),
+	INDEX(306),
+	SUB_FOR_DOLLAR_0(307),
+	SUB_FOR_DOLLAR_REFERENCE(308),
+	SUB_FOR_VARIABLE(309),
+	SUB_FOR_ARRAY_REFERENCE(310),
+	SPLIT(311),
+	SUBSTR(312),
+	TOLOWER(313),
+	TOUPPER(314),
+	SYSTEM(315),
+	SWAP(316),
+	ADD(317),
+	SUBTRACT(318),
+	MULTIPLY(319),
+	DIVIDE(320),
+	MOD(321),
+	POW(322),
+	INC(323),
+	DEC(324),
+	INC_ARRAY_REF(325),
+	DEC_ARRAY_REF(326),
+	INC_DOLLAR_REF(327),
+	DEC_DOLLAR_REF(328),
+	DUP(329),
+	NOT(330),
+	NEGATE(331),
+	CMP_EQ(332),
+	CMP_LT(333),
+	CMP_GT(334),
+	MATCHES(335),
+	SLEEP(336),
+	DUMP(337),
+	DEREF_ARRAY(338),
+	KEYLIST(339),
+	IS_EMPTY_KEYLIST(340),
+	GET_FIRST_AND_REMOVE_FROM_KEYLIST(341),
+	CHECK_CLASS(342),
+	GET_INPUT_FIELD(343),
+	CONSUME_INPUT(344),
+	GETLINE_INPUT(345),
+	USE_AS_FILE_INPUT(346),
+	USE_AS_COMMAND_INPUT(347),
+	NF_OFFSET(348),
+	NR_OFFSET(349),
+	FNR_OFFSET(350),
+	FS_OFFSET(351),
+	RS_OFFSET(352),
+	OFS_OFFSET(353),
+	RSTART_OFFSET(354),
+	RLENGTH_OFFSET(355),
+	FILENAME_OFFSET(356),
+	SUBSEP_OFFSET(357),
+	CONVFMT_OFFSET(358),
+	OFMT_OFFSET(359),
+	ENVIRON_OFFSET(360),
+	ARGC_OFFSET(361),
+	ARGV_OFFSET(362),
+	APPLY_RS(363),
+	CALL_FUNCTION(364),
+	FUNCTION(365),
+	SET_RETURN_RESULT(366),
+	RETURN_FROM_FUNCTION(367),
+	SET_NUM_GLOBALS(368),
+	CLOSE(369),
+	APPLY_SUBSEP(370),
+	DELETE_ARRAY_ELEMENT(371),
+	SET_EXIT_ADDRESS(372),
+	SET_WITHIN_END_BLOCKS(373),
+	EXIT_WITH_CODE(374),
+	REGEXP(375),
+	CONDITION_PAIR(376),
+	IS_IN(377),
+	CAST_INT(378),
+	CAST_DOUBLE(379),
+	CAST_STRING(380),
+	THIS(381),
+	EXTENSION(382),
+	EXEC(383),
+	DELETE_ARRAY(384),
+	UNARY_PLUS(385),
+	EXIT_WITHOUT_CODE(386),
+	ORS_OFFSET(387),
+	POSTINC(388),
+	POSTDEC(389),
+	SET_INPUT_FOR_EVAL(390),
+	;
+
+	private final int id;
+	private static final Map<Integer, Opcode> ID_MAP = new HashMap<>();
+
+	static {
+		for (Opcode op : values()) {
+			ID_MAP.put(op.id, op);
+		}
+	}
+
+	Opcode(int id) {
+		this.id = id;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public static Opcode fromId(int id) {
+		Opcode op = ID_MAP.get(id);
+		if (op == null) {
+			throw new IllegalArgumentException("Unknown opcode: " + id);
+		}
+		return op;
+	}
+}

--- a/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/PositionTracker.java
@@ -62,7 +62,7 @@ public class PositionTracker {
 		return "[" + idx + "]-->" + tuple.toString();
 	}
 
-	public int opcode() {
+	public Opcode opcode() {
 		return tuple.getOpcode();
 	}
 

--- a/src/main/java/org/metricshub/jawk/intermediate/Tuple.java
+++ b/src/main/java/org/metricshub/jawk/intermediate/Tuple.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
 class Tuple implements Serializable {
 
 	private static final long serialVersionUID = 8105941219003992817L;
-	private int opcode;
+	private Opcode opcode;
 	private long[] ints = new long[4];
 	private boolean[] bools = new boolean[4];
 	private double[] doubles = new double[4];
@@ -52,71 +52,71 @@ class Tuple implements Serializable {
 	private int lineno = -1;
 	private Tuple next = null;
 
-	Tuple(int opcode) {
+	Tuple(Opcode opcode) {
 		this.opcode = opcode;
 	}
 
-	Tuple(int opcode, long i1) {
+	Tuple(Opcode opcode, long i1) {
 		this(opcode);
 		ints[0] = i1;
 		types[0] = Long.class;
 	}
 
-	Tuple(int opcode, long i1, long i2) {
+	Tuple(Opcode opcode, long i1, long i2) {
 		this(opcode, i1);
 		ints[1] = i2;
 		types[1] = Long.class;
 	}
 
-	Tuple(int opcode, long i1, boolean b2) {
+	Tuple(Opcode opcode, long i1, boolean b2) {
 		this(opcode, i1);
 		bools[1] = b2;
 		types[1] = Boolean.class;
 	}
 
-	Tuple(int opcode, long i1, boolean b2, boolean b3) {
+	Tuple(Opcode opcode, long i1, boolean b2, boolean b3) {
 		this(opcode, i1, b2);
 		bools[2] = b3;
 		types[2] = Boolean.class;
 	}
 
-	Tuple(int opcode, double d1) {
+	Tuple(Opcode opcode, double d1) {
 		this(opcode);
 		doubles[0] = d1;
 		types[0] = Double.class;
 	}
 
-	Tuple(int opcode, String s1) {
+	Tuple(Opcode opcode, String s1) {
 		this(opcode);
 		strings[0] = s1;
 		types[0] = String.class;
 	}
 
-	Tuple(int opcode, boolean b1) {
+	Tuple(Opcode opcode, boolean b1) {
 		this(opcode);
 		bools[0] = b1;
 		types[0] = Boolean.class;
 	}
 
-	Tuple(int opcode, String s1, long i2) {
+	Tuple(Opcode opcode, String s1, long i2) {
 		this(opcode, s1);
 		ints[1] = i2;
 		types[1] = Long.class;
 	}
 
-	Tuple(int opcode, Address address) {
+	Tuple(Opcode opcode, Address address) {
 		this(opcode);
 		this.address = address;
 		types[0] = Address.class;
 	}
 
-	Tuple(int opcode, String strarg, long intarg, boolean boolarg) {
+	Tuple(Opcode opcode, String strarg, long intarg, boolean boolarg) {
 		this(opcode, strarg, intarg);
 		bools[2] = boolarg;
 		types[2] = Boolean.class;
 	}
 
-	Tuple(int opcode, Supplier<Address> addressSupplier, String s2, long i3, long i4) {
+	Tuple(Opcode opcode, Supplier<Address> addressSupplier, String s2, long i3, long i4) {
 		this(opcode);
 		this.addressSupplier = addressSupplier;
 		strings[1] = s2;
@@ -127,13 +127,13 @@ class Tuple implements Serializable {
 		types[3] = Long.class;
 	}
 
-	Tuple(int opcode, Class<?> cls) {
+	Tuple(Opcode opcode, Class<?> cls) {
 		this(opcode);
 		this.cls = cls;
 		types[0] = Class.class;
 	}
 
-	Tuple(int opcode, String s1, String s2) {
+	Tuple(Opcode opcode, String s1, String s2) {
 		this(opcode, s1);
 		strings[1] = s2;
 		types[1] = String.class;
@@ -160,7 +160,7 @@ class Tuple implements Serializable {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(AwkTuples.toOpcodeString(opcode));
+		sb.append(opcode.name());
 		int idx = 0;
 		while ((idx < types.length) && (types[idx] != null)) {
 			sb.append(", ");
@@ -203,7 +203,7 @@ class Tuple implements Serializable {
 		}
 	}
 
-	int getOpcode() {
+	Opcode getOpcode() {
 		return opcode;
 	}
 


### PR DESCRIPTION
## Summary
- introduce `Opcode` enum mapping all opcode ids and `fromId` lookup
- store `Opcode` in `Tuple` and adjust helper classes to use enum
- simplify tuple construction and dispatch to rely on `Opcode`

## Testing
- `mvn -e verify`


------
https://chatgpt.com/codex/tasks/task_b_68b1d61c99dc832189502c7f72fb8f68