### PR TITLE
Split compile and interpret settings

### DIFF
--- a/src/main/java/org/metricshub/jawk/backend/AVM.java
+++ b/src/main/java/org/metricshub/jawk/backend/AVM.java
@@ -61,6 +61,7 @@ import org.metricshub.jawk.jrt.RegexTokenizer;
 import org.metricshub.jawk.jrt.SingleCharacterTokenizer;
 import org.metricshub.jawk.jrt.VariableManager;
 import org.metricshub.jawk.util.AwkLogger;
+import org.metricshub.jawk.util.AwkInterpreteSettings;
 import org.metricshub.jawk.util.AwkSettings;
 import org.metricshub.jawk.util.ScriptSource;
 import org.metricshub.jawk.jrt.BSDRandom;
@@ -81,12 +82,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * The interpreter runs completely independent of the frontend/intermediate step.
  * In fact, an intermediate file produced by Jawk is sufficient to
  * execute on this interpreter. The binding data-structure is
- * the AwkSettings, which can contain options pertinent to
+ * the AwkInterpreteSettings, which can contain options pertinent to
  * the interpreter. For example, the interpreter must know about
  * the -v command line argument values, as well as the file/variable list
  * parameter values (ARGC/ARGV) after the script on the command line.
  * However, if programmatic access to the AVM is required, meaningful
- * AwkSettings are not required.
+ * AwkInterpreteSettings are not required.
  * <p>
  * Semantic analysis has occurred prior to execution of the interpreter.
  * Therefore, the interpreter throws AwkRuntimeExceptions upon most
@@ -124,7 +125,7 @@ public class AVM implements VariableManager {
 		operandStack.push(o);
 	}
 
-	private final AwkSettings settings;
+	private final AwkInterpreteSettings settings;
 
 	/**
 	 * Construct the interpreter.
@@ -153,7 +154,7 @@ public class AVM implements VariableManager {
 	 * @param extensions Map of the extensions to load
 	 */
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "constructor stores provided settings and extension map for later use")
-	public AVM(final AwkSettings parameters, final Map<String, JawkExtension> extensions) {
+	public AVM(final AwkInterpreteSettings parameters, final Map<String, JawkExtension> extensions) {
 		if (parameters != null) {
 			this.settings = parameters;
 			locale = settings.getLocale();
@@ -179,7 +180,7 @@ public class AVM implements VariableManager {
 			jrt.setStreams(settings.getOutputStream(), System.err);
 		}
 		for (JawkExtension ext : this.extensions.values()) {
-			ext.init(this, jrt, settings); // this = VariableManager
+			ext.init(this, jrt, (AwkSettings) settings); // this = VariableManager
 		}
 	}
 

--- a/src/main/java/org/metricshub/jawk/util/AwkCompileSettings.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkCompileSettings.java
@@ -1,0 +1,69 @@
+package org.metricshub.jawk.util;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.util.List;
+
+/**
+ * Settings used during compilation of AWK scripts.
+ */
+public interface AwkCompileSettings {
+
+	/**
+	 * Script sources meta info.
+	 *
+	 * @return the script sources to compile
+	 */
+	List<ScriptSource> getScriptSources();
+
+	/**
+	 * @return {@code true} to enable additional functions
+	 */
+	boolean isAdditionalFunctions();
+
+	/**
+	 * @return {@code true} to enable additional type functions
+	 */
+	boolean isAdditionalTypeFunctions();
+
+	/**
+	 * @return {@code true} to dump the syntax tree
+	 */
+	boolean isDumpSyntaxTree();
+
+	/**
+	 * @return {@code true} to dump the intermediate code
+	 */
+	boolean isDumpIntermediateCode();
+
+	/**
+	 * @return {@code true} to write intermediate code to a file
+	 */
+	boolean isWriteIntermediateFile();
+
+	/**
+	 * @param defaultFileName default file name to use
+	 * @return the output file name
+	 */
+	String getOutputFilename(String defaultFileName);
+}

--- a/src/main/java/org/metricshub/jawk/util/AwkInterpreteSettings.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkInterpreteSettings.java
@@ -1,0 +1,59 @@
+package org.metricshub.jawk.util;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Settings used during interpretation of AWK tuples.
+ */
+public interface AwkInterpreteSettings {
+
+	InputStream getInput();
+
+	Map<String, Object> getVariables();
+
+	List<String> getNameValueOrFileNames();
+
+	String getFieldSeparator();
+
+	boolean isUseSortedArrayKeys();
+
+	boolean isCatchIllegalFormatExceptions();
+
+	boolean isAdditionalFunctions();
+
+	boolean isAdditionalTypeFunctions();
+
+	PrintStream getOutputStream();
+
+	Locale getLocale();
+
+	String getDefaultRS();
+
+	String getDefaultORS();
+}

--- a/src/main/java/org/metricshub/jawk/util/AwkParameters.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkParameters.java
@@ -176,8 +176,6 @@ public final class AwkParameters {
 					checkParameterHasArgument(args, argIdx);
 					++argIdx;
 					settings.setLocale(new Locale(args[argIdx]));
-				} else if (args[argIdx].equals("-ext")) {
-					settings.setUserExtensions(true);
 				} else if (args[argIdx].equals("-h") || args[argIdx].equals("-?")) {
 					if (args.length > 1) {
 						throw new IllegalArgumentException("When printing help/usage output, we do not accept other arguments.");

--- a/src/main/java/org/metricshub/jawk/util/AwkSettings.java
+++ b/src/main/java/org/metricshub/jawk/util/AwkSettings.java
@@ -39,7 +39,7 @@ import java.util.Map;
  *
  * @author Danny Daglas
  */
-public class AwkSettings {
+public class AwkSettings implements AwkCompileSettings, AwkInterpreteSettings {
 
 	/**
 	 * Where input is read from.
@@ -119,8 +119,6 @@ public class AwkSettings {
 	 * Whether user extensions are enabled;
 	 * <code>false</code> by default.
 	 */
-	private boolean userExtensions = false;
-
 	/**
 	 * Write to intermediate file;
 	 * <code>false</code> by default.
@@ -484,26 +482,6 @@ public class AwkSettings {
 	 */
 	public void setUseSortedArrayKeys(boolean useSortedArrayKeys) {
 		this.useSortedArrayKeys = useSortedArrayKeys;
-	}
-
-	/**
-	 * Whether user extensions are enabled;
-	 * <code>false</code> by default.
-	 *
-	 * @return the userExtensions
-	 */
-	public boolean isUserExtensions() {
-		return userExtensions;
-	}
-
-	/**
-	 * Whether user extensions are enabled;
-	 * <code>false</code> by default.
-	 *
-	 * @param userExtensions the userExtensions to set
-	 */
-	public void setUserExtensions(boolean userExtensions) {
-		this.userExtensions = userExtensions;
 	}
 
 	/**

--- a/src/test/java/org/metricshub/jawk/AwkTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTest.java
@@ -628,7 +628,7 @@ public class AwkTest {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		settings.setOutputStream(new PrintStream(out, false, StandardCharsets.UTF_8.name()));
 
-		new Awk().invoke(tuples, settings, Collections.emptyMap());
+		new Awk(Collections.emptyMap()).invoke(tuples, settings);
 
 		assertEquals("value\n", out.toString(StandardCharsets.UTF_8.name()));
 	}


### PR DESCRIPTION
## Summary
- Separate compilation and interpretation configuration via new AwkCompileSettings and AwkInterpreteSettings interfaces.
- Persist extension map on Awk instances and adjust constructors accordingly.
- Remove per-invocation user extension flag and update tests.

## Testing
- `mvn formatter:format`
- `mvn license:update-file-header`
- `mvn -e verify`


------
https://chatgpt.com/codex/tasks/task_b_68b4aca78ec48321973ed959138fc909