### PR TITLE
Refactor Awk APIs to be instance-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ See [Jawk CLI documentation](https://metricshub.org/Jawk/cli.html)
 Execute a script in just one line using the convenience methods on `Awk`:
 
 ```java
-String result = Awk.run("{ print toupper($0) }", "hello world");
+Awk awk = new Awk();
+String result = awk.run("{ print toupper($0) }", "hello world");
 ```
 
 See [AWK in Java documentation](https://metricshub.org/Jawk/java.html) for more details and advanced usage.

--- a/src/main/java/org/metricshub/jawk/Awk.java
+++ b/src/main/java/org/metricshub/jawk/Awk.java
@@ -179,7 +179,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(String script, String input)
+	public String run(String script, String input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -199,7 +199,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(String script, String input, OutputStream output)
+	public void run(String script, String input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -217,7 +217,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(Reader script, String input)
+	public String run(Reader script, String input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -237,7 +237,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(Reader script, String input, OutputStream output)
+	public void run(Reader script, String input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -255,7 +255,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(String script, Reader input)
+	public String run(String script, Reader input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -275,7 +275,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(String script, Reader input, OutputStream output)
+	public void run(String script, Reader input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -293,7 +293,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(Reader script, Reader input)
+	public String run(Reader script, Reader input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -313,7 +313,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(Reader script, Reader input, OutputStream output)
+	public void run(Reader script, Reader input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -331,7 +331,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(String script, File input)
+	public String run(String script, File input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -351,7 +351,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(String script, File input, OutputStream output)
+	public void run(String script, File input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -371,7 +371,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(Reader script, File input)
+	public String run(Reader script, File input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -391,7 +391,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(Reader script, File input, OutputStream output)
+	public void run(Reader script, File input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -411,7 +411,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(String script, InputStream input)
+	public String run(String script, InputStream input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -431,7 +431,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(String script, InputStream input, OutputStream output)
+	public void run(String script, InputStream input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -449,7 +449,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static String run(Reader script, InputStream input)
+	public String run(Reader script, InputStream input)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -469,7 +469,7 @@ public class Awk {
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 * @throws ExitException if the script terminates with a non-zero exit code
 	 */
-	public static void run(Reader script, InputStream input, OutputStream output)
+	public void run(Reader script, InputStream input, OutputStream output)
 			throws IOException,
 			ClassNotFoundException,
 			ExitException {
@@ -480,7 +480,7 @@ public class Awk {
 	 * Internal method that configures default {@link AwkSettings} and executes
 	 * the AWK script.
 	 */
-	private static void run(
+	private void run(
 			Reader scriptReader,
 			InputStream inputStream,
 			OutputStream outputStream,
@@ -513,9 +513,8 @@ public class Awk {
 								scriptReader,
 								false));
 
-		Awk awk = new Awk();
 		try {
-			awk.invoke(settings);
+			invoke(settings);
 		} catch (ExitException e) {
 			if (e.getCode() != 0) {
 				throw e;
@@ -532,7 +531,7 @@ public class Awk {
 	 * @throws IOException if an I/O error occurs during compilation
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 */
-	public static AwkTuples compile(String script) throws IOException, ClassNotFoundException {
+	public AwkTuples compile(String script) throws IOException, ClassNotFoundException {
 		return compile(new StringReader(script));
 	}
 
@@ -545,12 +544,10 @@ public class Awk {
 	 * @throws IOException if an I/O error occurs during compilation
 	 * @throws ClassNotFoundException if intermediate code cannot be loaded
 	 */
-	public static AwkTuples compile(Reader script) throws IOException, ClassNotFoundException {
+	public AwkTuples compile(Reader script) throws IOException, ClassNotFoundException {
 		AwkSettings settings = new AwkSettings();
 		settings.addScriptSource(new ScriptSource(ScriptSource.DESCRIPTION_COMMAND_LINE_SCRIPT, script, false));
-
-		Awk awk = new Awk();
-		return awk.compile(settings);
+		return compile(settings);
 	}
 
 	public AwkTuples compile(AwkCompileSettings settings)
@@ -633,11 +630,10 @@ public class Awk {
 	 * <p>
 	 *
 	 * @param expression AWK expression to compile to AwkTuples
-	 * @param extensions Extensions that can be used in the expression
 	 * @return AwkTuples to be interpreted by AVM
 	 * @throws IOException if anything goes wrong with the compilation
 	 */
-	public static AwkTuples compileForEval(String expression, Map<String, JawkExtension> extensions) throws IOException {
+	public AwkTuples compileForEval(String expression) throws IOException {
 
 		// Create a ScriptSource
 		ScriptSource expressionSource = new ScriptSource(
@@ -646,7 +642,7 @@ public class Awk {
 				false);
 
 		// Parse the expression
-		AwkParser parser = new AwkParser(false, false, extensions);
+		AwkParser parser = new AwkParser(false, false, this.extensions);
 		AstNode ast = parser.parseExpression(expressionSource);
 
 		// Create the tuples that we will return
@@ -680,8 +676,8 @@ public class Awk {
 	 * @return the value of the specified expression
 	 * @throws IOException if anything goes wrong with the evaluation
 	 */
-	public static Object eval(String expression) throws IOException {
-		return eval(expression, null, null, Collections.emptyMap());
+	public Object eval(String expression) throws IOException {
+		return eval(expression, null, null);
 	}
 
 	/**
@@ -694,39 +690,8 @@ public class Awk {
 	 * @return the value of the specified expression
 	 * @throws IOException if anything goes wrong with the evaluation
 	 */
-	public static Object eval(String expression, String input) throws IOException {
-		return eval(expression, input, null, Collections.emptyMap());
-	}
-
-	/**
-	 * Evaluates the specified AWK expression (not a full script, just an expression)
-	 * and returns the value of this expression.
-	 * <p>
-	 *
-	 * @param expression Expression to evaluate (e.g. <code>2+3</code> or <code>$2 "-" $3</code>
-	 * @param input Optional text input (that will be available as $0, and tokenized as $1, $2, etc.)
-	 * @param fieldSeparator Value of the FS global variable used for parsing the input
-	 * @return the value of the specified expression
-	 * @throws IOException if anything goes wrong with the evaluation
-	 */
-	public static Object eval(String expression, String input, String fieldSeparator) throws IOException {
-		return eval(expression, input, fieldSeparator, Collections.emptyMap());
-	}
-
-	/**
-	 * Evaluates the specified AWK expression (not a full script, just an expression)
-	 * and returns the value of this expression.
-	 * <p>
-	 *
-	 * @param expression Expression to evaluate (e.g. <code>2+3</code> or <code>$2 "-" $3</code>
-	 * @param input Optional text input (that will be available as $0, and tokenized as $1, $2, etc.)
-	 * @param extensions Extensions that can be used in the expression
-	 * @return the value of the specified expression
-	 * @throws IOException if anything goes wrong with the evaluation
-	 */
-	public static Object eval(String expression, String input, Map<String, JawkExtension> extensions)
-			throws IOException {
-		return eval(expression, input, null, extensions);
+	public Object eval(String expression, String input) throws IOException {
+		return eval(expression, input, null);
 	}
 
 	/**
@@ -737,17 +702,11 @@ public class Awk {
 	 * @param expression Expression to evaluate (e.g. <code>2+3</code> or <code>$2 "-" $3</code>
 	 * @param input Optional text input (that will be available as $0, and tokenized as $1, $2, etc.)
 	 * @param fieldSeparator Value of the FS global variable used for parsing the input
-	 * @param extensions Extensions that can be used in the expression
 	 * @return the value of the specified expression
 	 * @throws IOException if anything goes wrong with the evaluation
 	 */
-	public static Object eval(
-			String expression,
-			String input,
-			String fieldSeparator,
-			Map<String, JawkExtension> extensions)
-			throws IOException {
-		return eval(compileForEval(expression, Collections.emptyMap()), input, fieldSeparator, extensions);
+	public Object eval(String expression, String input, String fieldSeparator) throws IOException {
+		return eval(compileForEval(expression), input, fieldSeparator);
 	}
 
 	/**
@@ -755,19 +714,13 @@ public class Awk {
 	 * TERNARY_EXPRESSION AST (the value that has been pushed in the stack).
 	 * <p>
 	 *
-	 * @param tuples Tuples returned by {@link Awk#compileForEval(String, Map)}
+	 * @param tuples Tuples returned by {@link Awk#compileForEval(String)}
 	 * @param input Optional text input (that will be available as $0, and tokenized as $1, $2, etc.)
 	 * @param fieldSeparator Value of the FS global variable used for parsing the input
-	 * @param extensions Extensions that can be used in the expression
 	 * @return the value of the specified expression
 	 * @throws IOException if anything goes wrong with the evaluation
 	 */
-	public static Object eval(
-			AwkTuples tuples,
-			String input,
-			String fieldSeparator,
-			Map<String, JawkExtension> extensions)
-			throws IOException {
+	public Object eval(AwkTuples tuples, String input, String fieldSeparator) throws IOException {
 
 		AwkSettings settings = new AwkSettings();
 		if (input != null) {
@@ -784,7 +737,7 @@ public class Awk {
 				.setOutputStream(
 						new PrintStream(new ByteArrayOutputStream(), false, StandardCharsets.UTF_8.name()));
 
-		AVM avm = new AVM(settings, extensions);
+		AVM avm = new AVM(settings, this.extensions);
 		return avm.eval(tuples, input);
 	}
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -26,25 +26,26 @@ scripts.
 ### Evaluate an expression
 
 ```java
-Object value = Awk.eval("2 + 3");
+Object value = new Awk().eval("2 + 3");
 ```
 
 ### Run a script directly
 
 ```java
-String output = Awk.run("{ print $1 }", "foo bar");
+String output = new Awk().run("{ print $1 }", "foo bar");
 ```
 
 ### Compile and invoke a script
 
 ```java
-AwkTuples tuples = Awk.compile("{ print $0 }");
+Awk awk = new Awk();
+AwkTuples tuples = awk.compile("{ print $0 }");
 AwkSettings settings = new AwkSettings();
 // configure input/output streams here
-new Awk().invoke(tuples, settings);
+awk.invoke(tuples, settings);
 ```
 
-`compileForEval(...)` and `Awk.eval(AwkTuples, ...)` provide the same workflow
+`compileForEval(...)` and `eval(AwkTuples, ...)` provide the same workflow
 for expressions.
 
 See [AWK in Java documentation](java.html) for advanced examples.

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -24,20 +24,23 @@ Jawk artifacts are published on Maven Central, so the dependency can be resolved
 ### Evaluate expressions with `Awk.eval()`
 
 ```java
-Object value = Awk.eval("2 + 3");
+Awk awk = new Awk();
+Object value = awk.eval("2 + 3");
 ```
 
 ### Quick execution with `Awk.run()`
 
 ```java
-String result = Awk.run("{ print toupper($0) }", "hello world");
+Awk awk = new Awk();
+String result = awk.run("{ print toupper($0) }", "hello world");
 ```
 
 ### Compile and invoke scripts
 
 ```java
+Awk awk = new Awk();
 String script = "{ print $0 }";
-AwkTuples tuples = Awk.compile(script);
+AwkTuples tuples = awk.compile(script);
 
 AwkSettings settings = new AwkSettings();
 settings.setInput(new ByteArrayInputStream("foo\nbar\n".getBytes(StandardCharsets.UTF_8)));
@@ -46,18 +49,19 @@ settings.setDefaultORS("\n");
 ByteArrayOutputStream out = new ByteArrayOutputStream();
 settings.setOutputStream(new PrintStream(out, false, StandardCharsets.UTF_8.name()));
 
-new Awk().invoke(tuples, settings);
+awk.invoke(tuples, settings);
 
 System.out.println(out.toString(StandardCharsets.UTF_8.name()));
 ```
 
-To supply custom extensions, use `invoke(AwkTuples, AwkSettings, Map<String, JawkExtension>)`.
+To supply custom extensions, create the `Awk` instance with a map of extensions.
 
 ### Precompile expressions
 
 ```java
-AwkTuples expr = Awk.compileForEval("$1 - $2", Collections.emptyMap());
-Object value = Awk.eval(expr, "5 3", " ");
+Awk awk = new Awk();
+AwkTuples expr = awk.compileForEval("$1 - $2");
+Object value = awk.eval(expr, "5 3", " ");
 ```
 
 ### Advanced examples
@@ -118,7 +122,8 @@ private String runAwk(File scriptFile, List<String> inputFileList) throws IOExce
  */
 private String runAwk(String script, String input) throws IOException, ExitException {
 
-    AwkTuples tuples = Awk.compile(new StringReader(script));
+    Awk awk = new Awk();
+    AwkTuples tuples = awk.compile(new StringReader(script));
 
     AwkSettings settings = new AwkSettings();
 
@@ -134,7 +139,6 @@ private String runAwk(String script, String input) throws IOException, ExitExcep
     settings.setOutputStream(new PrintStream(resultBytesStream));
 
     // Execute the awk script against the specified input
-    Awk awk = new Awk();
     awk.invoke(tuples, settings);
 
     // Return the result as a string

--- a/src/test/java/org/metricshub/jawk/AwkParserTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkParserTest.java
@@ -8,29 +8,31 @@ import org.metricshub.jawk.frontend.ast.LexerException;
 
 public class AwkParserTest {
 
+	private static final Awk AWK = new Awk();
+
 	@Test
 	public void testStringParsing() throws Exception {
-		assertEquals("'\\\\' must become \\", "\\", Awk.eval("\"\\\\\" "));
-		assertEquals("'\\a' must become BEL", "\u0007", Awk.eval("\"\\a\" "));
-		assertEquals("'\\b' must become BS", "\u0008", Awk.eval("\"\\b\" "));
-		assertEquals("'\\f' must become FF", "\014", Awk.eval("\"\\f\" "));
-		assertEquals("'\\n' must become LF", "\n", Awk.eval("\"\\n\" "));
-		assertEquals("'\\r' must become CR", "\r", Awk.eval("\"\\r\" "));
-		assertEquals("'\\t' must become TAB", "\t", Awk.eval("\"\\t\" "));
-		assertEquals("'\\v' must become VT", "\u000B", Awk.eval("\"\\v\" "));
-		assertEquals("'\\33' must become ESC", "\u001B", Awk.eval("\"\\33\" "));
-		assertEquals("'\\1!' must become {0x01, 0x21}", "\u0001!", Awk.eval("\"\\1!\" "));
-		assertEquals("'\\19' must become {0x01, 0x39}", "\u00019", Awk.eval("\"\\19\" "));
-		assertEquals("'\\38' must become {0x03, 0x38}", "\u00038", Awk.eval("\"\\38\" "));
-		assertEquals("'\\132' must become Z", "Z", Awk.eval("\"\\132\" "));
-		assertEquals("'\\1320' must become Z0", "Z0", Awk.eval("\"\\1320\" "));
-		assertEquals("'\\\"' must become \"", "\"", Awk.eval("\"\\\"\" "));
-		assertEquals("'\\x1B' must become ESC", "\u001B", Awk.eval("\"\\x1B\" "));
-		assertEquals("'\\x1b' must become ESC", "\u001B", Awk.eval("\"\\x1b\" "));
-		assertEquals("'\\x1!' must become {0x01, 0x21}", "\u0001!", Awk.eval("\"\\x1!\" "));
-		assertEquals("'\\x1G' must become {0x01, 0x47}", "\u0001G", Awk.eval("\"\\x1G\" "));
-		assertEquals("'\\x21A' must become !A", "!A", Awk.eval("\"\\x21A\" "));
-		assertEquals("'\\x!' must become x!", "x!", Awk.eval("\"\\x!\" "));
+		assertEquals("'\\\\' must become \\", "\\", AWK.eval("\"\\\\\" "));
+		assertEquals("'\\a' must become BEL", "\u0007", AWK.eval("\"\\a\" "));
+		assertEquals("'\\b' must become BS", "\u0008", AWK.eval("\"\\b\" "));
+		assertEquals("'\\f' must become FF", "\014", AWK.eval("\"\\f\" "));
+		assertEquals("'\\n' must become LF", "\n", AWK.eval("\"\\n\" "));
+		assertEquals("'\\r' must become CR", "\r", AWK.eval("\"\\r\" "));
+		assertEquals("'\\t' must become TAB", "\t", AWK.eval("\"\\t\" "));
+		assertEquals("'\\v' must become VT", "\u000B", AWK.eval("\"\\v\" "));
+		assertEquals("'\\33' must become ESC", "\u001B", AWK.eval("\"\\33\" "));
+		assertEquals("'\\1!' must become {0x01, 0x21}", "\u0001!", AWK.eval("\"\\1!\" "));
+		assertEquals("'\\19' must become {0x01, 0x39}", "\u00019", AWK.eval("\"\\19\" "));
+		assertEquals("'\\38' must become {0x03, 0x38}", "\u00038", AWK.eval("\"\\38\" "));
+		assertEquals("'\\132' must become Z", "Z", AWK.eval("\"\\132\" "));
+		assertEquals("'\\1320' must become Z0", "Z0", AWK.eval("\"\\1320\" "));
+		assertEquals("'\\\"' must become \"", "\"", AWK.eval("\"\\\"\" "));
+		assertEquals("'\\x1B' must become ESC", "\u001B", AWK.eval("\"\\x1B\" "));
+		assertEquals("'\\x1b' must become ESC", "\u001B", AWK.eval("\"\\x1b\" "));
+		assertEquals("'\\x1!' must become {0x01, 0x21}", "\u0001!", AWK.eval("\"\\x1!\" "));
+		assertEquals("'\\x1G' must become {0x01, 0x47}", "\u0001G", AWK.eval("\"\\x1G\" "));
+		assertEquals("'\\x21A' must become !A", "!A", AWK.eval("\"\\x21A\" "));
+		assertEquals("'\\x!' must become x!", "x!", AWK.eval("\"\\x!\" "));
 		assertThrows(
 				"Unfinished string by EOF must throw",
 				LexerException.class,
@@ -38,7 +40,7 @@ public class AwkParserTest {
 		assertThrows(
 				"Unfinished string by EOL must throw",
 				LexerException.class,
-				() -> Awk.eval("\"unfinished\n\""));
+				() -> AWK.eval("\"unfinished\n\""));
 		assertThrows(
 				"Interrupted octal number in string by EOF must throw",
 				LexerException.class,
@@ -46,7 +48,7 @@ public class AwkParserTest {
 		assertThrows(
 				"Interrupted octal number in string by EOL must throw",
 				LexerException.class,
-				() -> Awk.eval("\"unfinished\\0\n\""));
+				() -> AWK.eval("\"unfinished\\0\n\""));
 		assertThrows(
 				"Interrupted hex number in string by EOF must throw",
 				LexerException.class,
@@ -54,15 +56,15 @@ public class AwkParserTest {
 		assertThrows(
 				"Interrupted hex number in string by EOL must throw",
 				LexerException.class,
-				() -> Awk.eval("\"unfinished\\xf\n\""));
+				() -> AWK.eval("\"unfinished\\xf\n\""));
 	}
 
 	@Test
 	public void testMultiLineStatement() throws Exception {
 		assertEquals("|| must allow eol", "success", runAwk("BEGIN { if (0 || \n    1) { printf \"success\" } }", null));
 		assertEquals("&& must allow eol", "success", runAwk("BEGIN { if (1 && \n    1) { printf \"success\" } }", null));
-		assertEquals("? must allow eol", "success", Awk.eval("1 ?\n\"success\" : \"failed\" "));
-		assertEquals(": must allow eol", "success", Awk.eval("1 ? \"success\" :\n\"failed\" "));
+		assertEquals("? must allow eol", "success", AWK.eval("1 ?\n\"success\" : \"failed\" "));
+		assertEquals(": must allow eol", "success", AWK.eval("1 ? \"success\" :\n\"failed\" "));
 		assertEquals(", must allow eol", "success", runAwk("BEGIN { printf(\"%s\", \n\"success\") }", null));
 		assertEquals("do must allow eol", "success", runAwk("BEGIN { do\n printf \"success\"; while (0) }", null));
 		assertEquals(
@@ -73,7 +75,7 @@ public class AwkParserTest {
 
 	@Test
 	public void testUnaryPlus() throws Exception {
-		assertEquals("+a must convert a to number", 0L, Awk.eval("+a "));
+		assertEquals("+a must convert a to number", 0L, AWK.eval("+a "));
 	}
 
 	@Test
@@ -89,7 +91,7 @@ public class AwkParserTest {
 		assertEquals(
 				"Nested ternary must parse correctly",
 				2L,
-				Awk.eval("1 ? 2 : 3 ? 4 : 5 "));
+				AWK.eval("1 ? 2 : 3 ? 4 : 5 "));
 	}
 
 	@Test
@@ -112,8 +114,8 @@ public class AwkParserTest {
 
 	@Test
 	public void testPow() throws Exception {
-		assertEquals("^ (pow) operator must be supported", 256L, Awk.eval("2^8 "));
-		assertEquals("** (pow) operator must be supported", 256L, Awk.eval("2**8 "));
+		assertEquals("^ (pow) operator must be supported", 256L, AWK.eval("2^8 "));
+		assertEquals("** (pow) operator must be supported", 256L, AWK.eval("2**8 "));
 	}
 
 	@Test
@@ -141,11 +143,11 @@ public class AwkParserTest {
 				"2211",
 				runAwk("{ a = 3; printf $--a ; printf a ; printf $(--a) ; printf a }", "1 2 3"));
 		assertEquals("++ precedes ^", "22", runAwk("BEGIN { a = 1; printf(2^a++); printf a }", null));
-		assertEquals("^ precedes unary -", -1L, Awk.eval("-1^2"));
-		assertEquals("^ precedes unary !", 1, Awk.eval("!0^2"));
-		assertEquals("Unary - precedes *", -2L, Awk.eval("0 + -1 * 2"));
-		assertEquals("* precedes +", 5L, Awk.eval("1 + 2 * 2"));
-		assertEquals("+ precedes string concat", "33", Awk.eval("1 + 2 3"));
+		assertEquals("^ precedes unary -", -1L, AWK.eval("-1^2"));
+		assertEquals("^ precedes unary !", 1, AWK.eval("!0^2"));
+		assertEquals("Unary - precedes *", -2L, AWK.eval("0 + -1 * 2"));
+		assertEquals("* precedes +", 5L, AWK.eval("1 + 2 * 2"));
+		assertEquals("+ precedes string concat", "33", AWK.eval("1 + 2 3"));
 	}
 
 	@Test
@@ -161,6 +163,6 @@ public class AwkParserTest {
 		assertThrows(
 				"Unfinished regexp by EOL must throw",
 				LexerException.class,
-				() -> Awk.eval("/unfinished\n/"));
+				() -> AWK.eval("/unfinished\n/"));
 	}
 }

--- a/src/test/java/org/metricshub/jawk/AwkTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTest.java
@@ -65,6 +65,8 @@ public class AwkTest {
 	@Rule
 	public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().muteForSuccessfulTests();
 
+	private static final Awk AWK = new Awk();
+
 	String[] linesOutput() {
 		return systemOutRule.getLog().split(EOL);
 	}
@@ -231,15 +233,15 @@ public class AwkTest {
 
 	@Test
 	public void testNot() throws Exception {
-		assertEquals("!0 must return 1", 1, Awk.eval("!0"));
-		assertEquals("!1 must return 0", 0, Awk.eval("!1"));
-		assertEquals("!0.0 must return 1", 1, Awk.eval("!0.0"));
-		assertEquals("!0.1 must return 0", 0, Awk.eval("!0.1"));
-		assertEquals("!2^31 must return 0", 0, Awk.eval("!2^31"));
-		assertEquals("!2^33 must return 0", 0, Awk.eval("!2^33"));
-		assertEquals("!\"\" must return 1", 1, Awk.eval("!\"\""));
-		assertEquals("!\"a\" must return 0", 0, Awk.eval("!\"a\""));
-		assertEquals("!uninitialized must return true", 1, Awk.eval("!uninitialized"));
+		assertEquals("!0 must return 1", 1, AWK.eval("!0"));
+		assertEquals("!1 must return 0", 0, AWK.eval("!1"));
+		assertEquals("!0.0 must return 1", 1, AWK.eval("!0.0"));
+		assertEquals("!0.1 must return 0", 0, AWK.eval("!0.1"));
+		assertEquals("!2^31 must return 0", 0, AWK.eval("!2^31"));
+		assertEquals("!2^33 must return 0", 0, AWK.eval("!2^33"));
+		assertEquals("!\"\" must return 1", 1, AWK.eval("!\"\""));
+		assertEquals("!\"a\" must return 0", 0, AWK.eval("!\"a\""));
+		assertEquals("!uninitialized must return true", 1, AWK.eval("!uninitialized"));
 	}
 
 	@Test
@@ -311,12 +313,12 @@ public class AwkTest {
 
 	@Test
 	public void testPrintfC() throws Exception {
-		assertEquals("A", Awk.eval("sprintf(\"%c\", 65)"));
+		assertEquals("A", AWK.eval("sprintf(\"%c\", 65)"));
 	}
 
 	@Test
 	public void testConcatenationLeftAssociativity() throws Exception {
-		assertEquals("Concatenated elements must be eval'ed from left to right", "0123", Awk.eval("a++ a++ a++ a++"));
+		assertEquals("Concatenated elements must be eval'ed from left to right", "0123", AWK.eval("a++ a++ a++ a++"));
 	}
 
 	@Test
@@ -329,7 +331,7 @@ public class AwkTest {
 
 	@Test
 	public void testAtan2ArgumentsLeftAssociativity() throws Exception {
-		assertEquals("atan2 arguments must be eval'ed from left to right", 0.0, Awk.eval("atan2(a++, a++)"));
+		assertEquals("atan2 arguments must be eval'ed from left to right", 0.0, AWK.eval("atan2(a++, a++)"));
 	}
 
 	@Test
@@ -361,17 +363,17 @@ public class AwkTest {
 		assertEquals(
 				"Chained additions and subtractions must be eval'ed from left to right",
 				6L,
-				Awk.eval("10 - 3 - 2 + 1"));
+				AWK.eval("10 - 3 - 2 + 1"));
 	}
 
 	@Test
 	public void testChainedMultiplicationsAndDivisionsLeftAssociativity() throws Exception {
-		assertEquals("Chained multiplies and divides must be eval'ed from left to right", 5L, Awk.eval("12 / 3 / 4 * 5"));
+		assertEquals("Chained multiplies and divides must be eval'ed from left to right", 5L, AWK.eval("12 / 3 / 4 * 5"));
 	}
 
 	@Test
 	public void testChainedExponentiationRightAssociativity() throws Exception {
-		assertEquals("Chained powers must be eval'ed from right to left", 4L, Awk.eval("256 ^ 0.5 ^ 4 ^ 0.5"));
+		assertEquals("Chained powers must be eval'ed from right to left", 4L, AWK.eval("256 ^ 0.5 ^ 4 ^ 0.5"));
 	}
 
 	// Additional tests to further cover left associativity:
@@ -405,7 +407,7 @@ public class AwkTest {
 		assertEquals(
 				"Chained string concatenation must be eval'ed from left to right",
 				"abcde",
-				Awk.eval("\"a\" \"b\" \"c\" \"d\" \"e\""));
+				AWK.eval("\"a\" \"b\" \"c\" \"d\" \"e\""));
 	}
 
 	@Test
@@ -413,22 +415,22 @@ public class AwkTest {
 		assertEquals(
 				"Complex expression with mixed operators must be eval'ed from left to right",
 				8L,
-				Awk.eval("10 + 12 / 3 * 2 - 6 / 3 * 5"));
+				AWK.eval("10 + 12 / 3 * 2 - 6 / 3 * 5"));
 	}
 
 	@Test
 	public void testSubstr() throws Exception {
-		assertEquals("234", Awk.eval("substr(\"12345\", 2, 3)"));
-		assertEquals("2345", Awk.eval("substr(\"12345\", 2, 10)"));
-		assertEquals("123", Awk.eval("substr(\"12345\", 0, 3)"));
-		assertEquals("123", Awk.eval("substr(\"12345\", -1, 3)"));
-		assertEquals("", Awk.eval("substr(\"12345\", 2, 0)").toString());
-		assertEquals("", Awk.eval("substr(\"12345\", 2, -1)").toString());
-		assertEquals("", Awk.eval("substr(\"12345\", -1, -1)").toString());
-		assertEquals("", Awk.eval("substr(\"12345\", 10, 3)").toString());
-		assertEquals("2345", Awk.eval("substr(\"12345\", 2)"));
-		assertEquals("12345", Awk.eval("substr(\"12345\", 0)"));
-		assertEquals("12345", Awk.eval("substr(\"12345\", -1)"));
+		assertEquals("234", AWK.eval("substr(\"12345\", 2, 3)"));
+		assertEquals("2345", AWK.eval("substr(\"12345\", 2, 10)"));
+		assertEquals("123", AWK.eval("substr(\"12345\", 0, 3)"));
+		assertEquals("123", AWK.eval("substr(\"12345\", -1, 3)"));
+		assertEquals("", AWK.eval("substr(\"12345\", 2, 0)").toString());
+		assertEquals("", AWK.eval("substr(\"12345\", 2, -1)").toString());
+		assertEquals("", AWK.eval("substr(\"12345\", -1, -1)").toString());
+		assertEquals("", AWK.eval("substr(\"12345\", 10, 3)").toString());
+		assertEquals("2345", AWK.eval("substr(\"12345\", 2)"));
+		assertEquals("12345", AWK.eval("substr(\"12345\", 0)"));
+		assertEquals("12345", AWK.eval("substr(\"12345\", -1)"));
 	}
 
 	@Test
@@ -557,35 +559,35 @@ public class AwkTest {
 
 	@Test
 	public void testEvalNumericExpression() throws Exception {
-		Object result = Awk.eval("1 + 2", null);
+		Object result = AWK.eval("1 + 2", null);
 		assertTrue(result instanceof Number);
 		assertEquals(3, ((Number) result).intValue());
 	}
 
 	@Test
 	public void testEvalFieldExtraction() throws Exception {
-		Object result = Awk.eval("$2", "my text input");
+		Object result = AWK.eval("$2", "my text input");
 		assertEquals("text", result);
 	}
 
 	@Test
 	public void testEvalNF() throws Exception {
-		Object result = Awk.eval("NF", "a b c");
+		Object result = AWK.eval("NF", "a b c");
 		assertEquals(3, ((Number) result).intValue());
 	}
 
 	@Test
 	public void testEvalFailsStatement() throws Exception {
-		assertThrows(ParserException.class, () -> Awk.eval("print 3.14", null));
-		assertThrows(ParserException.class, () -> Awk.eval("1 + 2, 3", null));
-		assertThrows(ParserException.class, () -> Awk.eval("1 + 2 ; 3 + 4", null));
-		assertThrows(ParserException.class, () -> Awk.eval("BEGIN { print 5 }", null));
+		assertThrows(ParserException.class, () -> AWK.eval("print 3.14", null));
+		assertThrows(ParserException.class, () -> AWK.eval("1 + 2, 3", null));
+		assertThrows(ParserException.class, () -> AWK.eval("1 + 2 ; 3 + 4", null));
+		assertThrows(ParserException.class, () -> AWK.eval("BEGIN { print 5 }", null));
 	}
 
 	@Test
 	public void compileFromString() throws Exception {
 		String script = "{ print $0 }";
-		AwkTuples tuples = Awk.compile(script);
+		AwkTuples tuples = AWK.compile(script);
 
 		AwkSettings settings = new AwkSettings();
 		settings.setInput(new ByteArrayInputStream("foo\nbar\n".getBytes(StandardCharsets.UTF_8)));
@@ -602,7 +604,7 @@ public class AwkTest {
 	@Test
 	public void compileFromReader() throws Exception {
 		String script = "{ print $0 }";
-		AwkTuples tuples = Awk.compile(new StringReader(script));
+		AwkTuples tuples = AWK.compile(new StringReader(script));
 
 		AwkSettings settings = new AwkSettings();
 		settings.setInput(new ByteArrayInputStream("one\n".getBytes(StandardCharsets.UTF_8)));
@@ -619,7 +621,7 @@ public class AwkTest {
 	@Test
 	public void invokeWithExplicitExtensions() throws Exception {
 		String script = "{ print $0 }";
-		AwkTuples tuples = Awk.compile(script);
+		AwkTuples tuples = AWK.compile(script);
 
 		AwkSettings settings = new AwkSettings();
 		settings.setInput(new ByteArrayInputStream("value\n".getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
## Summary
- make Awk.run, compile, eval, and compileForEval instance methods so they rely on `this.extensions`
- update tests and documentation to use an Awk instance

## Testing
- `mvn formatter:format`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_b_68b4b79710908321b00e31041817b44b