### PR TITLE
Refine extension metadata APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Jawk does not rely on any logging framework; errors are reported through standar
 
 See [Jawk CLI documentation](https://metricshub.org/Jawk/cli.html)
 for command-line options, including `-K <filename>` to compile a script
-to a tuples file and `-l <filename>` to load previously compiled tuples.
+to a tuples file and `-L <filename>` to load previously compiled tuples.
+Use `--list-ext` to display available extensions (with their human readable
+names) and `-l <extension>` or `--load <extension>` to load them by extension
+name, simple class name, or fully qualified class name.
 
 ## Run AWK inside Java
 

--- a/src/main/java/org/metricshub/jawk/Awk.java
+++ b/src/main/java/org/metricshub/jawk/Awk.java
@@ -91,7 +91,7 @@ public class Awk {
 	 * Create a new instance of Awk without extensions
 	 */
 	public Awk() {
-		this.extensions = Collections.emptyMap();
+		this(Collections.<String, JawkExtension>emptyMap(), true);
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class Awk {
 	 * @param extensions extension instances implementing {@link JawkExtension}
 	 */
 	public Awk(Collection<? extends JawkExtension> extensions) {
-		this.extensions = createKeywordMap(extensions);
+		this(createKeywordMap(extensions), true);
 	}
 
 	/**
@@ -110,7 +110,11 @@ public class Awk {
 	 */
 	@SafeVarargs
 	public Awk(JawkExtension... extensions) {
-		this(Arrays.asList(extensions));
+		this(createKeywordMap(Arrays.asList(extensions)), true);
+	}
+
+	private Awk(Map<String, JawkExtension> keywordMap, @SuppressWarnings("unused") boolean alreadyValidated) {
+		this.extensions = keywordMap == null ? Collections.<String, JawkExtension>emptyMap() : keywordMap;
 	}
 
 	static Map<String, JawkExtension> createKeywordMap(Collection<? extends JawkExtension> extensions) {

--- a/src/main/java/org/metricshub/jawk/Awk.java
+++ b/src/main/java/org/metricshub/jawk/Awk.java
@@ -32,18 +32,16 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.StringReader;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.metricshub.jawk.backend.AVM;
+import org.metricshub.jawk.ext.ExtensionRegistry;
 import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.frontend.AwkParser;
 import org.metricshub.jawk.frontend.AstNode;
@@ -73,25 +71,14 @@ import org.metricshub.jawk.util.ScriptSource;
  * And the number of times tuples are traversed is depends
  * on whether interpretation or compilation takes place.
  * <p>
- * By default a minimal set of extensions are automatically
- * included. Please refer to the EXTENSION_PREFIX static field
- * contents for an up-to-date list. As of the initial release
- * of the extension system, the prefix defines the following
- * extensions:
- * <ul>
- * <li>CoreExtension
- * <li>SocketExtension
- * <li>StdinExtension
- * </ul>
+ * The engine does not enable any extensions automatically. Extensions can be
+ * provided programmatically via the {@link Awk#Awk(Collection)} constructors or
+ * via the command line when using the CLI entry point.
  *
  * @see org.metricshub.jawk.backend.AVM
  * @author Danny Daglas
  */
 public class Awk {
-
-	private static final String DEFAULT_EXTENSIONS = org.metricshub.jawk.ext.CoreExtension.class.getName()
-			+ "#"
-			+ org.metricshub.jawk.ext.StdinExtension.class.getName();
 
 	private final Map<String, JawkExtension> extensions;
 
@@ -108,10 +95,50 @@ public class Awk {
 	}
 
 	/**
-	 * Create a new instance of Awk with the specified extensions
+	 * Create a new instance of Awk with the specified extension instances.
+	 *
+	 * @param extensions extension instances implementing {@link JawkExtension}
 	 */
-	public Awk(Map<String, JawkExtension> extensions) {
-		this.extensions = new HashMap<String, JawkExtension>(extensions);
+	public Awk(Collection<? extends JawkExtension> extensions) {
+		this.extensions = createKeywordMap(extensions);
+	}
+
+	/**
+	 * Create a new instance of Awk with the specified extension instances.
+	 *
+	 * @param extensions extension instances implementing {@link JawkExtension}
+	 */
+	@SafeVarargs
+	public Awk(JawkExtension... extensions) {
+		this(Arrays.asList(extensions));
+	}
+
+	static Map<String, JawkExtension> createKeywordMap(Collection<? extends JawkExtension> extensions) {
+		if (extensions == null || extensions.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		Map<String, JawkExtension> keywordMap = new LinkedHashMap<String, JawkExtension>();
+		for (JawkExtension extension : extensions) {
+			if (extension == null) {
+				throw new IllegalArgumentException("Extension instance must not be null");
+			}
+			for (String keyword : extension.extensionKeywords()) {
+				JawkExtension previous = keywordMap.putIfAbsent(keyword, extension);
+				if (previous != null && previous != extension) {
+					throw new IllegalArgumentException(
+							"Keyword '" + keyword + "' already provided by "
+									+ previous.getExtensionName());
+				}
+			}
+		}
+		return Collections.unmodifiableMap(keywordMap);
+	}
+
+	static Map<String, JawkExtension> createKeywordMap(JawkExtension... extensions) {
+		if (extensions == null || extensions.length == 0) {
+			return Collections.emptyMap();
+		}
+		return createKeywordMap(Arrays.asList(extensions));
 	}
 
 	/**
@@ -789,77 +816,13 @@ public class Awk {
 	}
 
 	/**
-	 * Discovers and instantiates the default set of {@link JawkExtension}s used by
-	 * Jawk. Additional extensions can be specified via the
-	 * {@code jawk.extensions} system property, whose value is a {@code #}-separated
-	 * list of fully qualified class names.
+	 * Lists metadata for the {@link JawkExtension} implementations discovered on
+	 * the class path.
 	 *
-	 * @return map of extension keywords to their implementing
-	 *         {@link JawkExtension} instances
+	 * @return list of discovered extension descriptors
 	 */
-	public static Map<String, JawkExtension> getDefaultExtensions() {
-		String extensionsStr = System.getProperty("jawk.extensions", null);
-		if (extensionsStr == null) {
-			// return Collections.emptyMap();
-			extensionsStr = DEFAULT_EXTENSIONS;
-		} else {
-			extensionsStr = DEFAULT_EXTENSIONS + "#" + extensionsStr;
-		}
-
-		// use reflection to obtain extensions
-
-		Set<Class<?>> extensionClasses = new HashSet<Class<?>>();
-		Map<String, JawkExtension> retval = new HashMap<String, JawkExtension>();
-
-		StringTokenizer st = new StringTokenizer(extensionsStr, "#");
-		while (st.hasMoreTokens()) {
-			String cls = st.nextToken();
-			try {
-				Class<?> c = Class.forName(cls);
-				// check if it's a JawkExtension
-				if (!JawkExtension.class.isAssignableFrom(c)) {
-					throw new ClassNotFoundException(cls + " does not implement JawkExtension");
-				}
-				if (extensionClasses.contains(c)) {
-					throw new IllegalArgumentException(
-							"class " + cls + " is multiple times referred in extension class list.");
-				} else {
-					extensionClasses.add(c);
-				}
-
-				// it is...
-				// create a new instance and put it here
-				try {
-					Constructor<?> constructor = c.getDeclaredConstructor(); // Default constructor
-					JawkExtension ji = (JawkExtension) constructor.newInstance();
-					String[] keywords = ji.extensionKeywords();
-					for (String keyword : keywords) {
-						if (retval.get(keyword) != null) {
-							throw new IllegalArgumentException(
-									"keyword collision : "
-											+ keyword
-											+ " for both "
-											+ retval.get(keyword).getExtensionName()
-											+ " and "
-											+ ji.getExtensionName());
-						}
-						retval.put(keyword, ji);
-					}
-				} catch (
-						InstantiationException
-						| IllegalAccessException
-						| NoSuchMethodException
-						| SecurityException
-						| IllegalArgumentException
-						| InvocationTargetException e) {
-					throw new IllegalStateException("Cannot instantiate " + c.getName(), e);
-				}
-			} catch (ClassNotFoundException cnfe) {
-				throw new IllegalStateException("Cannot classload " + cls, cnfe);
-			}
-		}
-
-		return retval;
+	public static Map<String, JawkExtension> listAvailableExtensions() {
+		return ExtensionRegistry.listExtensions();
 	}
 
 }

--- a/src/main/java/org/metricshub/jawk/Cli.java
+++ b/src/main/java/org/metricshub/jawk/Cli.java
@@ -36,8 +36,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.metricshub.jawk.ext.ExtensionRegistry;
+import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.frontend.AstNode;
 import org.metricshub.jawk.intermediate.AwkTuples;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
@@ -68,6 +72,8 @@ public final class Cli {
 
 	private final List<ScriptSource> scriptSources = new ArrayList<ScriptSource>();
 	private AwkTuples precompiledTuples;
+	private final List<String> extensionSpecs = new ArrayList<String>();
+	private boolean listExtensions;
 
 	private boolean dumpSyntaxTree;
 	private boolean dumpIntermediateCode;
@@ -118,7 +124,7 @@ public final class Cli {
 	}
 
 	/**
-	 * Returns the precompiled tuples loaded via the <code>-l</code> option, if any.
+	 * Returns the precompiled tuples loaded via the <code>-L</code> option, if any.
 	 *
 	 * @return the tuples or {@code null} if none were loaded
 	 */
@@ -155,8 +161,8 @@ public final class Cli {
 				// -f filename : load script from file
 				checkParameterHasArgument(args, argIdx);
 				scriptSources.add(new ScriptFileSource(args[++argIdx]));
-			} else if (arg.equals("-l")) {
-				// -l filename : load precompiled tuples
+			} else if (arg.equals("-L")) {
+				// -L filename : load precompiled tuples
 				checkParameterHasArgument(args, argIdx);
 				String file = args[++argIdx];
 				try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(file))) {
@@ -164,6 +170,16 @@ public final class Cli {
 				} catch (IOException | ClassNotFoundException ex) {
 					throw new IllegalArgumentException("Failed to read tuples '" + file + "': " + ex.getMessage(), ex);
 				}
+			} else if (arg.equals("-l") || arg.equals("--load")) {
+				// -l/--load extension : load extension
+				checkParameterHasArgument(args, argIdx);
+				extensionSpecs.add(args[++argIdx]);
+			} else if (arg.equals("--list-ext")) {
+				if (argIdx != 0 || args.length != 1) {
+					throw new IllegalArgumentException("When listing extensions, we do not accept other arguments.");
+				}
+				listExtensions = true;
+				return;
 			} else if (arg.equals("-K")) {
 				// -K filename : compile scripts to tuples and exit
 				checkParameterHasArgument(args, argIdx);
@@ -194,7 +210,7 @@ public final class Cli {
 				settings.setLocale(new Locale(args[++argIdx]));
 			} else if (arg.equals("-h") || arg.equals("-?")) {
 				// -h/-? : display usage information and exit
-				if (args.length > 1) {
+				if (argIdx != 0 || args.length != 1) {
 					throw new IllegalArgumentException("When printing help/usage output, we do not accept other arguments.");
 				}
 				printUsage = true;
@@ -296,7 +312,24 @@ public final class Cli {
 			usage(out);
 			return;
 		}
-		Awk awk = new Awk();
+		if (listExtensions) {
+			Map<String, JawkExtension> available = ExtensionRegistry.listExtensions();
+			for (Entry<String, JawkExtension> entry : available.entrySet()) {
+				out.println(entry.getKey() + " - " + entry.getValue().getClass().getName());
+			}
+			return;
+		}
+
+		List<JawkExtension> extensions = new ArrayList<JawkExtension>();
+		for (String spec : extensionSpecs) {
+			JawkExtension extension = ExtensionRegistry.resolve(spec);
+			if (extension == null) {
+				throw new IllegalArgumentException("Unknown extension '" + spec + "'");
+			}
+			extensions.add(extension);
+		}
+
+		Awk awk = extensions.isEmpty() ? new Awk() : new Awk(extensions);
 		// Use precompiled tuples if provided; otherwise compile the scripts now
 		AwkTuples tuples = precompiledTuples != null ? precompiledTuples : awk.compile(scriptSources);
 		if (dumpSyntaxTree) {
@@ -348,22 +381,27 @@ public final class Cli {
 								JAR_NAME +
 								" [-F fs_val]" +
 								" [-f script-filename]" +
-								" [-l tuples-filename]" +
+								" [-L tuples-filename]" +
 								" [-K tuples-filename]" +
 								" [-o output-filename]" +
 								" [-S]" +
 								" [-s]" +
 								" [-r]" +
 								" [--locale locale]" +
-								" [-ext]" +
 								" [-t]" +
+								" [-l extension]..." +
 								" [-v name=val]..." +
 								" [script]" +
 								" [name=val | input_filename]...");
 		dest.println();
+		dest.println("java -jar " + JAR_NAME + " --list-ext");
+		dest.println();
 		dest.println(" -F fs_val = Use fs_val for FS.");
 		dest.println(" -f filename = Use contents of filename for script.");
-		dest.println(" -l filename = Load precompiled tuples from filename.");
+		dest.println(" -L filename = Load precompiled tuples from filename.");
+		dest.println(" -l extension = Load an extension by extension name or class name.");
+		dest.println(" --load extension = Same as -l.");
+		dest.println("                      Extensions must already be on the class path before loading them.");
 		dest.println(" -v name=val = Initial awk variable assignments.");
 		dest.println();
 		dest.println(" -t = (extension) Maintain array keys in sorted order.");
@@ -373,7 +411,7 @@ public final class Cli {
 		dest.println(" -s = (extension) Write the intermediate code to file. (default: avm.lst)");
 		dest.println(" -r = (extension) Do NOT hide IllegalFormatExceptions for [s]printf.");
 		dest.println(" --locale Locale = (extension) Specify a locale to be used instead of US-English");
-		dest.println("-ext= (extension) Enable user-defined extensions. (default: not enabled)");
+		dest.println(" --list-ext = (extension) List available extensions.");
 		dest.println();
 		dest.println(" -h or -? = (extension) This help screen.");
 	}

--- a/src/main/java/org/metricshub/jawk/ext/AbstractExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/AbstractExtension.java
@@ -22,6 +22,7 @@ package org.metricshub.jawk.ext;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.util.Collection;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.metricshub.jawk.jrt.IllegalAwkArgumentException;
 import org.metricshub.jawk.jrt.JRT;
@@ -42,6 +43,18 @@ public abstract class AbstractExtension implements JawkExtension {
 	private JRT jrt;
 	private VariableManager vm;
 	private AwkSettings settings;
+
+	/** {@inheritDoc} */
+	@Override
+	public String getExtensionName() {
+		return getClass().getSimpleName();
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public Collection<String> extensionKeywords() {
+		throw new UnsupportedOperationException("Extensions must override extensionKeywords()");
+	}
 
 	/** {@inheritDoc} */
 	@Override

--- a/src/main/java/org/metricshub/jawk/ext/CoreExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/CoreExtension.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.metricshub.jawk.NotImplementedError;
 import org.metricshub.jawk.jrt.AssocArray;
 import org.metricshub.jawk.jrt.AwkRuntimeException;
@@ -283,6 +284,7 @@ public class CoreExtension extends AbstractExtension implements JawkExtension {
 
 	/** {@inheritDoc} */
 	@Override
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Keywords collection is immutable")
 	public Collection<String> extensionKeywords() {
 		return KEYWORDS;
 	}

--- a/src/main/java/org/metricshub/jawk/ext/CoreExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/CoreExtension.java
@@ -26,9 +26,12 @@ import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.metricshub.jawk.NotImplementedError;
 import org.metricshub.jawk.jrt.AssocArray;
@@ -197,9 +200,44 @@ import org.metricshub.jawk.jrt.VariableManager;
  */
 public class CoreExtension extends AbstractExtension implements JawkExtension {
 
-	// Singleton instance for this extension
 	private static CoreExtension instance = null;
 	private static final Object INSTANCE_LOCK = new Object();
+
+	public static final CoreExtension INSTANCE = new CoreExtension();
+
+	private static final List<String> KEYWORDS = Collections
+			.unmodifiableList(
+					Arrays
+							.asList(
+									"Array", // i.e. Array(array,1,3,5,7,9,11)
+									"Map", // i.e. Map(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
+									"HashMap", // i.e. HashMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
+									"TreeMap", // i.e. TreeMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
+									"LinkedMap", // i.e. LinkedMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3",
+																// 4))
+									"MapUnion", // i.e. MapUnion(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3",
+															// 4))
+									"MapCopy", // i.e. cnt = MapCopy(aaTarget, aaSource)
+									"TypeOf", // i.e. typestring = TypeOf(item)
+									"String", // i.e. str = String(3)
+									"Double", // i.e. dbl = Double(3)
+									"Halt", // i.e. Halt()
+									"Dereference", // i.e. f(Dereference(r1))
+									"DeRef", // i.e. (see above, but replace Dereference with DeRef)
+									"NewReference", // i.e. ref = NewReference(Map("hi","there"))
+									"NewRef", // i.e. (see above, but replace Reference with Ref)
+									"Unreference", // i.e. b = Unreference(ref)
+									"UnRef", // i.e. (see above, but replace Unreference with UnRef)
+									"InRef", // i.e. while(k = InRef(r2)) [ same as for(k in assocarr) ]
+									"IsInRef", // i.e. if (IsInRef(r1, "key")) [ same as if("key" in assocarr) ]
+									"DumpRefs", // i.e. DumpRefs()
+									"Timeout", // i.e. r = Timeout(300)
+									"Throw", // i.e. Throw("this is an awkruntimeexception")
+									"Version", // i.e. print Version(aa)
+									"Date", // i.e. str = Date()
+									"FileExists" // i.e. b = FileExists("/a/b/c")
+							));
+
 	private int refMapIdx = 0;
 	private Map<String, Object> referenceMap = new HashMap<String, Object>();
 	private Map<AssocArray, Iterator<?>> iterators = new HashMap<AssocArray, Iterator<?>>();
@@ -238,42 +276,15 @@ public class CoreExtension extends AbstractExtension implements JawkExtension {
 		}
 	}
 
-	/** {@inheritDoc} */
 	@Override
 	public String getExtensionName() {
-		return "Core Extension";
+		return "core";
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public String[] extensionKeywords() {
-		return new String[] {
-				"Array", // i.e. Array(array,1,3,5,7,9,11)
-				"Map", // i.e. Map(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
-				"HashMap", // i.e. HashMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
-				"TreeMap", // i.e. TreeMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
-				"LinkedMap", // i.e. LinkedMap(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
-				"MapUnion", // i.e. MapUnion(assocarray, "hi", "there", "testing", 3, 5, Map("item1", "item2", "i3", 4))
-				"MapCopy", // i.e. cnt = MapCopy(aaTarget, aaSource)
-				"TypeOf", // i.e. typestring = TypeOf(item)
-				"String", // i.e. str = String(3)
-				"Double", // i.e. dbl = Double(3)
-				"Halt", // i.e. Halt()
-				"Dereference", // i.e. f(Dereference(r1))
-				"DeRef", // i.e. (see above, but replace Dereference with DeRef)
-				"NewReference", // i.e. ref = NewReference(Map("hi","there"))
-				"NewRef", // i.e. (see above, but replace Reference with Ref)
-				"Unreference", // i.e. b = Unreference(ref)
-				"UnRef", // i.e. (see above, but replace Unreference with UnRef)
-				"InRef", // i.e. while(k = InRef(r2)) [ same as for(k in assocarr) ]
-				"IsInRef", // i.e. if (IsInRef(r1, "key")) [ same as if("key" in assocarr) ]
-				"DumpRefs", // i.e. DumpRefs()
-				"Timeout", // i.e. r = Timeout(300)
-				"Throw", // i.e. Throw("this is an awkruntimeexception")
-				"Version", // i.e. print Version(aa)
-				"Date", // i.e. str = Date()
-				"FileExists" // i.e. b = FileExists("/a/b/c")
-		};
+	public Collection<String> extensionKeywords() {
+		return KEYWORDS;
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/metricshub/jawk/ext/ExtensionRegistry.java
+++ b/src/main/java/org/metricshub/jawk/ext/ExtensionRegistry.java
@@ -1,0 +1,202 @@
+package org.metricshub.jawk.ext;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Registry used by extensions and the CLI to expose ready-to-use extension
+ * instances.
+ */
+public final class ExtensionRegistry {
+
+	private static final ConcurrentMap<String, JawkExtension> REGISTERED = new ConcurrentHashMap<String, JawkExtension>();
+
+	static {
+		registerBuiltin(
+				CoreExtension.INSTANCE,
+				CoreExtension.class.getName(),
+				CoreExtension.class.getSimpleName(),
+				"Core Extension");
+		registerBuiltin(
+				StdinExtension.INSTANCE,
+				StdinExtension.class.getName(),
+				StdinExtension.class.getSimpleName(),
+				"Stdin Support");
+	}
+
+	private ExtensionRegistry() {}
+
+	/**
+	 * Registers an extension instance under the supplied name.
+	 *
+	 * @param name identifying name
+	 * @param extension extension instance
+	 */
+	public static void register(String name, JawkExtension extension) {
+		Objects.requireNonNull(name, "Extension name must not be null");
+		if (name.isEmpty()) {
+			throw new IllegalArgumentException("Extension name must not be empty");
+		}
+		REGISTERED.put(name, Objects.requireNonNull(extension, "Extension instance must not be null"));
+	}
+
+	private static void registerBuiltin(JawkExtension extension, String... identifiers) {
+		Objects.requireNonNull(extension, "Extension instance must not be null");
+		if (identifiers != null) {
+			for (String identifier : identifiers) {
+				if (identifier != null && !identifier.isEmpty()) {
+					REGISTERED.putIfAbsent(identifier, extension);
+				}
+			}
+		}
+		String name = extension.getExtensionName();
+		if (name != null && !name.isEmpty()) {
+			REGISTERED.putIfAbsent(name, extension);
+		}
+	}
+
+	/**
+	 * Returns a snapshot of all registered extensions sorted by name.
+	 *
+	 * @return immutable view of registered extensions
+	 */
+	public static Map<String, JawkExtension> listExtensions() {
+		List<Map.Entry<String, JawkExtension>> entries = new ArrayList<Map.Entry<String, JawkExtension>>(
+				REGISTERED.entrySet());
+		Collections.sort(entries, Comparator.comparing(Map.Entry::getKey, String.CASE_INSENSITIVE_ORDER));
+		Map<String, JawkExtension> snapshot = new LinkedHashMap<String, JawkExtension>();
+		for (Map.Entry<String, JawkExtension> entry : entries) {
+			snapshot.put(entry.getKey(), entry.getValue());
+		}
+		return Collections.unmodifiableMap(snapshot);
+	}
+
+	/**
+	 * Resolves an extension name to the registered instance. The lookup is
+	 * case-insensitive and also supports class names. When the extension has not
+	 * yet been registered, the method attempts to load the class by name and
+	 * instantiate it.
+	 *
+	 * @param name name or class name of the extension
+	 * @return extension instance, or {@code null} when the name cannot be resolved
+	 */
+	public static JawkExtension resolve(String name) {
+		if (name == null || name.isEmpty()) {
+			return null;
+		}
+		JawkExtension extension = REGISTERED.get(name);
+		if (extension != null) {
+			return extension;
+		}
+		extension = findCaseInsensitive(name);
+		if (extension != null) {
+			return extension;
+		}
+		extension = findByClassName(name);
+		if (extension != null) {
+			return extension;
+		}
+		extension = instantiateByClassName(name);
+		if (extension != null) {
+			return extension;
+		}
+		return null;
+	}
+
+	private static JawkExtension findCaseInsensitive(String name) {
+		for (Map.Entry<String, JawkExtension> entry : REGISTERED.entrySet()) {
+			if (entry.getKey().equalsIgnoreCase(name)) {
+				return entry.getValue();
+			}
+		}
+		return null;
+	}
+
+	private static JawkExtension findByClassName(String name) {
+		for (JawkExtension extension : REGISTERED.values()) {
+			Class<? extends JawkExtension> type = extension.getClass();
+			if (type.getName().equals(name)
+					|| type.getSimpleName().equals(name)
+					|| type.getName().equalsIgnoreCase(name)
+					|| type.getSimpleName().equalsIgnoreCase(name)) {
+				return extension;
+			}
+		}
+		return null;
+	}
+
+	private static JawkExtension instantiateByClassName(String name) {
+		try {
+			Class<?> clazz = Class.forName(name);
+			if (!JawkExtension.class.isAssignableFrom(clazz)) {
+				return null;
+			}
+			JawkExtension created = clazz.asSubclass(JawkExtension.class).getDeclaredConstructor().newInstance();
+			JawkExtension instance = created;
+			String simpleName = clazz.getSimpleName();
+			if (!simpleName.isEmpty()) {
+				JawkExtension existing = REGISTERED.putIfAbsent(simpleName, created);
+				if (existing != null) {
+					instance = existing;
+				}
+			}
+			String extensionName = instance.getExtensionName();
+			if (extensionName != null && !extensionName.isEmpty()) {
+				JawkExtension existingByName = REGISTERED.putIfAbsent(extensionName, instance);
+				if (existingByName != null) {
+					instance = existingByName;
+					extensionName = instance.getExtensionName();
+				}
+			}
+			if (!simpleName.isEmpty()) {
+				REGISTERED.put(simpleName, instance);
+			}
+			if (extensionName != null && !extensionName.isEmpty()) {
+				REGISTERED.put(extensionName, instance);
+			}
+			register(name, instance);
+			return instance;
+		} catch (ClassNotFoundException ex) {
+			return null;
+		} catch (InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+			throw new IllegalStateException("Cannot instantiate extension " + name, e);
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof RuntimeException) {
+				throw (RuntimeException) cause;
+			}
+			throw new IllegalStateException("Cannot instantiate extension " + name, cause);
+		}
+	}
+
+}

--- a/src/main/java/org/metricshub/jawk/ext/ExtensionRegistry.java
+++ b/src/main/java/org/metricshub/jawk/ext/ExtensionRegistry.java
@@ -75,13 +75,23 @@ public final class ExtensionRegistry {
 		if (identifiers != null) {
 			for (String identifier : identifiers) {
 				if (identifier != null && !identifier.isEmpty()) {
-					REGISTERED.putIfAbsent(identifier, extension);
+					JawkExtension existing = REGISTERED.putIfAbsent(identifier, extension);
+					if (existing != null && existing != extension) {
+						throw new IllegalStateException(
+								"Extension identifier '" + identifier + "' already mapped to "
+										+ existing.getClass().getName());
+					}
 				}
 			}
 		}
 		String name = extension.getExtensionName();
 		if (name != null && !name.isEmpty()) {
-			REGISTERED.putIfAbsent(name, extension);
+			JawkExtension existing = REGISTERED.putIfAbsent(name, extension);
+			if (existing != null && existing != extension) {
+				throw new IllegalStateException(
+						"Extension name '" + name + "' already mapped to "
+								+ existing.getClass().getName());
+			}
 		}
 	}
 

--- a/src/main/java/org/metricshub/jawk/ext/JawkExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/JawkExtension.java
@@ -22,6 +22,7 @@ package org.metricshub.jawk.ext;
  * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
  */
 
+import java.util.Collection;
 import org.metricshub.jawk.jrt.JRT;
 import org.metricshub.jawk.jrt.VariableManager;
 import org.metricshub.jawk.util.AwkSettings;
@@ -91,14 +92,13 @@ public interface JawkExtension {
 	 * All the extended keywords supported
 	 * by this extension.
 	 * <p>
-	 * <strong>Note:</strong> Jawk will
-	 * throw a runtime exception if the
-	 * keyword collides with any other keyword
-	 * in the system, extension or otherwise.
+	 * Implementations must return an unmodifiable collection.
+	 * <strong>Note:</strong> Jawk will throw a runtime exception if the
+	 * keyword collides with any other keyword in the system, extension or otherwise.
 	 *
-	 * @return the list of keywords the extension provides support for
+	 * @return the keywords the extension provides support for
 	 */
-	String[] extensionKeywords();
+	Collection<String> extensionKeywords();
 
 	/**
 	 * Define the parameters which are <strong>expected</strong> to be

--- a/src/main/java/org/metricshub/jawk/ext/StdinExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/StdinExtension.java
@@ -26,6 +26,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.metricshub.jawk.NotImplementedError;
@@ -95,6 +99,18 @@ import org.metricshub.jawk.util.AwkSettings;
  */
 public class StdinExtension extends AbstractExtension implements JawkExtension {
 
+	public static final StdinExtension INSTANCE = new StdinExtension();
+
+	private static final List<String> KEYWORDS = Collections
+			.unmodifiableList(
+					Arrays
+							.asList(
+									// keyboard stuff
+									"StdinHasInput", // i.e. b = StdinHasInput()
+									"StdinGetline", // i.e. retcode = StdinGetline() # $0 = the input
+									"StdinBlock" // i.e. StdinBlock(...)
+							));
+
 	private static final Object DONE = new Object();
 
 	private final BlockingQueue<Object> getLineInput = new LinkedBlockingQueue<Object>();
@@ -154,21 +170,15 @@ public class StdinExtension extends AbstractExtension implements JawkExtension {
 		getLineInputThread.start();
 	}
 
-	/** {@inheritDoc} */
 	@Override
 	public String getExtensionName() {
-		return "Stdin Support";
+		return "stdin";
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public String[] extensionKeywords() {
-		return new String[] {
-				// keyboard stuff
-				"StdinHasInput", // i.e. b = StdinHasInput()
-				"StdinGetline", // i.e. retcode = StdinGetline() # $0 = the input
-				"StdinBlock" // i.e. StdinBlock(...)
-		};
+	public Collection<String> extensionKeywords() {
+		return KEYWORDS;
 	}
 
 	/** {@inheritDoc} */

--- a/src/main/java/org/metricshub/jawk/ext/StdinExtension.java
+++ b/src/main/java/org/metricshub/jawk/ext/StdinExtension.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.metricshub.jawk.NotImplementedError;
@@ -177,6 +178,7 @@ public class StdinExtension extends AbstractExtension implements JawkExtension {
 
 	/** {@inheritDoc} */
 	@Override
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Keywords collection is immutable")
 	public Collection<String> extensionKeywords() {
 		return KEYWORDS;
 	}

--- a/src/site/markdown/cli.md
+++ b/src/site/markdown/cli.md
@@ -96,12 +96,17 @@ To enhance development and script execution over traditional AWK, **Jawk** also 
 
 * `-t` - Maintain all associated arrays in key-sorted order. This is implemented by using a TreeMap instead of a HashMap as the backing store for the associated array.
 * `-K <filename>` - writes the tuples to `<filename>`, and then halts.
-* `-l <filename>` - load previously compiled tuples from the specified file.
+* `-L <filename>` - load previously compiled tuples from the specified file.
+* `-l <extension>`/`--load <extension>` - load an extension by its registered name, simple class name or fully qualified class name.
+* `--list-ext` - list available extensions and exit. The output contains the registered name followed by the implementing class and can be used as input for `-l`.
+
+When using extension names that contain spaces, wrap them in quotes so the shell passes the value as a single argument (for example `-l "My Custom Extension"`).
+
+You can rely on the JVM `-cp`/`-classpath` option to add directories or JARs containing extensions before launching `java -jar jawk-….jar`.
 * `-o <filename>` - Override the default output filename for extended parameters -S, -s, -z, and -Z.
 * `-S` - Dump the abstract syntax tree (constructed by the front end) to a text readable file. If the -o argument is not provided, the contents will be dumped into the `syntax_tree.lst` file.
 * `-s` - Dump the intermediate code (tuples) to a text readable file. If the -o argument is not provided, the contents will be dumped into the `"avm.lst"` file.
 * `-r` - Allow IllegalFormatExceptions to be thrown when using the java.util.Formatter class for printf/sprintf. If the argument is not provided, the interpreter/compiled result catches IllegalFormatExceptions and silently returns a blank string in its place. If the argument is provided, the interpreter/compiled result will halt by throwing this runtime exception.
-* `-ext` - Enables the parser/AVM to recognize extensions within scripts. Extensions allow for arbitrary Java code to be called as registered AWK functions. Please refer to the [Jawk Extension Facility Description](extensions.html) page for more information.
 * `-h`/`-?` - Displays a usage screen. The screen contains a list of command-line arguments and what each does.
 
 If `-f` is not provided, a script argument is expected here.

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -54,7 +54,21 @@ awk.invoke(tuples, settings);
 System.out.println(out.toString(StandardCharsets.UTF_8.name()));
 ```
 
-To supply custom extensions, create the `Awk` instance with a map of extensions.
+To supply custom extensions, create the `Awk` instance with the extension
+instances. Built-in extensions expose convenient singletons such as
+`CoreExtension.INSTANCE` and `StdinExtension.INSTANCE`:
+
+```java
+Awk awk = new Awk(CoreExtension.INSTANCE, new MyExtension());
+```
+
+Use `Awk.listAvailableExtensions()` to inspect the extensions discoverable on
+the current class path:
+
+```java
+Awk.listAvailableExtensions().forEach((name, extension) ->
+        System.out.println(name + " - " + extension.getClass().getName()));
+```
 
 ### Precompile expressions
 

--- a/src/test/java/org/metricshub/jawk/AvailableExtensionsTest.java
+++ b/src/test/java/org/metricshub/jawk/AvailableExtensionsTest.java
@@ -1,0 +1,71 @@
+package org.metricshub.jawk;
+
+/*-
+ * ╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲
+ * Jawk
+ * ჻჻჻჻჻჻
+ * Copyright (C) 2006 - 2025 MetricsHub
+ * ჻჻჻჻჻჻
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * ╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱╲╱
+ */
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import org.junit.Test;
+import org.metricshub.jawk.ext.CoreExtension;
+import org.metricshub.jawk.ext.JawkExtension;
+import org.metricshub.jawk.ext.StdinExtension;
+
+/**
+ * Tests discovery of available {@link org.metricshub.jawk.ext.JawkExtension}s.
+ */
+public class AvailableExtensionsTest {
+
+	@Test
+	public void testListAvailableExtensions() {
+		Map<String, JawkExtension> ext = Awk.listAvailableExtensions();
+		assertSame(CoreExtension.INSTANCE, ext.get("core"));
+		assertSame(StdinExtension.INSTANCE, ext.get("stdin"));
+	}
+
+	@Test
+	public void testExtensionNames() {
+		Map<String, JawkExtension> ext = Awk.listAvailableExtensions();
+		assertSame(CoreExtension.INSTANCE, ext.get(CoreExtension.class.getSimpleName()));
+		assertSame(CoreExtension.INSTANCE, ext.get(CoreExtension.class.getName()));
+		assertSame(StdinExtension.INSTANCE, ext.get(StdinExtension.class.getSimpleName()));
+		assertSame(StdinExtension.INSTANCE, ext.get(StdinExtension.class.getName()));
+		assertSame(CoreExtension.INSTANCE, ext.get("Core Extension"));
+		assertSame(StdinExtension.INSTANCE, ext.get("Stdin Support"));
+	}
+
+	@Test
+	public void testExtensionKeywords() {
+		Map<String, JawkExtension> keywordMap = Awk
+				.createKeywordMap(
+						CoreExtension.INSTANCE,
+						StdinExtension.INSTANCE);
+		assertTrue(keywordMap.get("Array") instanceof CoreExtension);
+		assertTrue(keywordMap.get("Map") instanceof CoreExtension);
+		assertTrue(keywordMap.get("StdinHasInput") instanceof StdinExtension);
+
+		JawkExtension customCore = new CoreExtension();
+		Map<String, JawkExtension> instanceMap = Awk.createKeywordMap(customCore);
+		assertSame(customCore, instanceMap.get("Array"));
+	}
+}

--- a/src/test/java/org/metricshub/jawk/AwkTest.java
+++ b/src/test/java/org/metricshub/jawk/AwkTest.java
@@ -645,13 +645,13 @@ public class AwkTest {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		settings.setOutputStream(new PrintStream(out, false, StandardCharsets.UTF_8.name()));
 
-		new Awk(Collections.emptyMap()).invoke(tuples, settings);
+		new Awk().invoke(tuples, settings);
 
 		assertEquals("value\n", out.toString(StandardCharsets.UTF_8.name()));
 	}
 
 	/**
-	 * Loads precompiled tuples from disk via the <code>-l</code> option and executes
+	 * Loads precompiled tuples from disk via the <code>-L</code> option and executes
 	 * them through the CLI.
 	 */
 	@Test
@@ -664,7 +664,7 @@ public class AwkTest {
 			oos.writeObject(tuples);
 		}
 
-		Cli cli = Cli.parseCommandLineArguments(new String[] { "-l", tmp.getAbsolutePath() });
+		Cli cli = Cli.parseCommandLineArguments(new String[] { "-L", tmp.getAbsolutePath() });
 		AwkSettings settings = cli.getSettings();
 		settings.setInput(new ByteArrayInputStream("abc\n".getBytes(StandardCharsets.UTF_8)));
 		settings.setDefaultRS("\n");
@@ -686,7 +686,7 @@ public class AwkTest {
 		File tmp = File.createTempFile("jawk", ".tpl");
 		Cli.main(new String[] { "-K", tmp.getAbsolutePath(), "{ print toupper($0) }" });
 
-		Cli cli = Cli.parseCommandLineArguments(new String[] { "-l", tmp.getAbsolutePath() });
+		Cli cli = Cli.parseCommandLineArguments(new String[] { "-L", tmp.getAbsolutePath() });
 		AwkSettings settings = cli.getSettings();
 		settings.setInput(new ByteArrayInputStream("abc\n".getBytes(StandardCharsets.UTF_8)));
 		settings.setDefaultRS("\n");

--- a/src/test/java/org/metricshub/jawk/TestExtension.java
+++ b/src/test/java/org/metricshub/jawk/TestExtension.java
@@ -1,5 +1,7 @@
 package org.metricshub.jawk;
 
+import java.util.Collection;
+import java.util.Collections;
 import org.metricshub.jawk.ext.AbstractExtension;
 import org.metricshub.jawk.ext.JawkExtension;
 import org.metricshub.jawk.jrt.AssocArray;
@@ -10,19 +12,10 @@ import org.metricshub.jawk.util.AwkSettings;
 public class TestExtension extends AbstractExtension implements JawkExtension {
 
 	private static final String MY_EXTENSION_FUNCTION = "myExtensionFunction";
+	private static final Collection<String> KEYWORDS = Collections.singletonList(MY_EXTENSION_FUNCTION);
 
 	@Override
 	public void init(VariableManager vm, JRT jrt, AwkSettings settings) {}
-
-	@Override
-	public String getExtensionName() {
-		return "TestExtension";
-	}
-
-	@Override
-	public String[] extensionKeywords() {
-		return new String[] { MY_EXTENSION_FUNCTION };
-	}
 
 	@Override
 	public int[] getAssocArrayParameterPositions(String extensionKeyword, int numArgs) {
@@ -31,6 +24,16 @@ public class TestExtension extends AbstractExtension implements JawkExtension {
 		} else {
 			return new int[] {};
 		}
+	}
+
+	@Override
+	public String getExtensionName() {
+		return "TestExtension";
+	}
+
+	@Override
+	public Collection<String> extensionKeywords() {
+		return KEYWORDS;
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- move keyword map creation into `Awk` and require extensions to expose unmodifiable keyword collections
- adjust the built-in extensions, registry, and tests to use the new metadata contract while preserving legacy names
- refresh CLI and extension documentation to demonstrate the updated naming and keyword patterns

## Testing
- mvn formatter:format
- mvn license:update-file-header
- mvn -e verify *(fails: known `org.metricshub.jawk.BwkTTest` differences)*

------
https://chatgpt.com/codex/tasks/task_b_68c7471ccfd883219058f6bfc3636ac2